### PR TITLE
Handle multiple account selection

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -73,6 +73,15 @@ const states = [
         }
     },
     {
+        name: "account selection",
+        selector: `#aadTile > div > div.table-cell.tile-img > img`,
+        async handler(page) {
+            debug("Multiple accounts associated with username.  Selecting first account");
+            await page.click("#aadTile > div > div.table-cell.tile-img > img");
+            await Bluebird.delay(500);
+        }
+    },
+    {
         name: "password input",
         selector: `input[name="passwd"]:not(.moveOffScreen)`,
         async handler(page) {

--- a/lib/login.js
+++ b/lib/login.js
@@ -76,8 +76,36 @@ const states = [
         name: "account selection",
         selector: `#aadTile > div > div.table-cell.tile-img > img`,
         async handler(page) {
-            debug("Multiple accounts associated with username.  Selecting first account");
-            await page.click("#aadTile > div > div.table-cell.tile-img > img");
+            debug("Multiple accounts associated with username.");
+            const aadTile = await page.$("#aadTileTitle");
+            const aadTileMessage = await page.evaluate(aadTile => aadTile.textContent, aadTile);
+
+            const msaTile = await page.$("#msaTileTitle");
+            const msaTileMessage = await page.evaluate(msaTile => msaTile.textContent, msaTile);
+
+            var accounts = [ { message: aadTileMessage, selector: "#aadTileTitle" }, { message: msaTileMessage, selector: "#msaTileTitle"  } ]
+
+            let account;
+            if (accounts.length === 0) {
+                throw new CLIError("No accounts found on account selection screen.");
+            } else if (accounts.length === 1) {
+                account = accounts[0];
+            } else {
+                debug("Asking user to choose account");
+                console.log("It looks like this Username is used with more than one account from Microsoft. Which one do you want to use?")
+                const answers = await inquirer.prompt([{
+                    name: "account",
+                    message: "Account:",
+                    type: "list",
+                    choices: _.map(accounts, "message"),
+                    default: aadTileMessage
+                }]);
+
+                account = _.find(accounts, ["message", answers.account]);
+            }
+
+            debug("Proceeding with account " + account.selector);
+            await page.click(account.selector);
             await Bluebird.delay(500);
         }
     },


### PR DESCRIPTION
When there are multiple accounts associated to an email address, there's an additional selection dialogue for choosing the account that is displayed prior to prompting for the account password.  This PR selects the first account. 