### PR TITLE
Set the token duration when there is only one role.

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -427,6 +427,7 @@ module.exports = {
             throw new CLIError("No roles found in SAML response.");
         } else if (roles.length === 1) {
             role = roles[0];
+            durationHours = defaultDurationHours;
         } else {
             debug("Asking user to choose role");
             const answers = await inquirer.prompt([{


### PR DESCRIPTION
Make sure to set `durationHours` if the SAML response only lists a single role.

Without this, for a response with 1 role you always get a `MalformedInput` error from the `sts.assumeRoleWithSAML` request.