### PR TITLE
resolve 30 second timeout waiting for login page in windows 10 on cor…

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -371,7 +371,7 @@ module.exports = {
 
             if ((headless) || (!headless && cliProxy)) {
                 debug("Going to login page");
-                await page.goto(url, { waitUntil: 'networkidle0' });
+                await page.goto(url, { waitUntil: 'domcontentloaded' });
             } else {
                 debug("Waiting for login page to load");
                 await page.waitForNavigation({ waitUntil: 'networkidle0' });


### PR DESCRIPTION
…porate network

We discovered problem where ALL domain joined windows 10 computers using aws-azure-login timed out after 30 seconds when on our corporate network.  The same computers do not experience this problem on home networks.  Mac and Linux do not seem to experience this problem.  Changing networkidle0 to domcontentloaded resolved the issue.