### PR TITLE
refactor new Buffer to class method Buffer.from

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -47,7 +47,7 @@ const states = [
 
             var username;
 
-            if (noPrompt && defaultUsername) { 
+            if (noPrompt && defaultUsername) {
                 debug("Not prompting user for username");
                 username = defaultUsername;
             } else {
@@ -58,7 +58,7 @@ const states = [
                     default: defaultUsername
                 }]));
             }
-            
+
             debug("Focusing on username input");
             await page.focus(`input[name="loginfmt"]`);
 
@@ -69,7 +69,7 @@ const states = [
 
             debug("Typing username");
             await page.keyboard.type(username);
-            
+
             debug("Submitting form");
             await page.click("input[type=submit]");
 
@@ -99,7 +99,7 @@ const states = [
 
             var password;
 
-            if (noPrompt && defaultPassword) { 
+            if (noPrompt && defaultPassword) {
                 debug("Not prompting user for password");
                 password = defaultPassword;
             } else {
@@ -110,7 +110,7 @@ const states = [
                     type: "password"
                 }]));
             }
-            
+
             debug("Focusing on password input");
             await page.focus(`input[name="Password"],input[name="passwd"]`);
 
@@ -446,7 +446,7 @@ module.exports = {
      */
     _parseRolesFromSamlResponse(assertion) {
         debug("Converting assertion from base64 to ASCII");
-        const samlText = new Buffer(assertion, 'base64').toString("ascii");
+        const samlText = new Buffer.from(assertion, 'base64').toString("ascii");
         debug("Converted", samlText);
 
         debug("Parsing SAML XML");
@@ -491,10 +491,10 @@ module.exports = {
             if (noPrompt && defaultRoleArn) {
                 role = _.find(roles, ["roleArn", defaultRoleArn]);
             }
-            
-            if (role) { 
+
+            if (role) {
                 debug("Valid role found. No need to ask.");
-            } else {       
+            } else {
                 debug("Asking user to choose role");
                 questions.push({
                     name: "role",
@@ -505,7 +505,7 @@ module.exports = {
                 });
             }
         }
-        
+
         if (noPrompt && defaultDurationHours) {
             durationHours = defaultDurationHours;
         } else {
@@ -521,7 +521,7 @@ module.exports = {
                 }
             });
         }
-        
+
         const answers = await inquirer.prompt(questions);
         if (!role) role = _.find(roles, ["roleArn", answers.role]);
         if (!durationHours) durationHours = answers.durationHours;


### PR DESCRIPTION
`new Buffer` is deprecated per https://nodejs.org/docs/latest-v8.x/api/buffer.html

Patched to updated class method `Buffer.from()`