### PR TITLE
Adds options to enable Chrome Network Service and no verify ssl for aws

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -17,17 +17,21 @@ commander
     .option("--mode <mode>", "'cli' to hide the login page and perform the login through the CLI (default behavior), 'gui' to perform the login through the Azure GUI (more reliable but only works on GUI operating system), 'debug' to show the login page but perform the login through the CLI (useful to debug issues with the CLI login)")
     .option("--no-sandbox", "Disable the Puppeteer sandbox (usually necessary on Linux)")
     .option("--no-prompt", "Do not prompt for input and accept the default choice", false)
+    .option("--enable-chrome-network-service", "Enable Chromium's Network Service (needed when login provider redirects with 3XX)")
+    .option("--no-verify-ssl", "Disable SSL Peer Verification for connections to AWS (no effect if behind proxy)")
     .parse(process.argv);
 
 const profileName = commander.profile || process.env.AWS_PROFILE || "default";
 const mode = commander.mode || 'cli';
 const disableSandbox = !commander.sandbox;
 const noPrompt = !commander.prompt;
+const enableChromeNetworkService = commander.enableChromeNetworkService;
+const awsNoVerifySsl = !commander.verifySsl;
 
 Promise.resolve()
     .then(() => {
         if (commander.configure) return configureProfileAsync(profileName);
-        return login.loginAsync(profileName, mode, disableSandbox, noPrompt);
+        return login.loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl);
     })
     .catch(err => {
         if (err.name === "CLIError") {

--- a/lib/login.js
+++ b/lib/login.js
@@ -13,18 +13,12 @@ const debug = require("debug")('aws-azure-login');
 const CLIError = require("./CLIError");
 const awsConfig = require("./awsConfig");
 const proxy = require('proxy-agent');
+const https = require('https');
 
 const WIDTH = 425;
 const HEIGHT = 550;
 const DELAY_ON_UNRECOGNIZED_PAGE = 1000;
 const MAX_UNRECOGNIZED_PAGE_DELAY = 30 * 1000;
-
-if (process.env.https_proxy) {
-    AWS.config.update({
-        httpOptions: { agent: proxy(process.env.https_proxy) }
-    });
-}
-const sts = new AWS.STS();
 
 /**
  * To proxy the input/output of the Azure login page, it's easiest to run a loop that
@@ -246,7 +240,7 @@ const states = [
 ];
 
 module.exports = {
-    async loginAsync(profileName, mode, disableSandbox, noPrompt) {
+    async loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl) {
         let headless, cliProxy;
         if (mode === 'cli') {
             headless = true;
@@ -263,10 +257,10 @@ module.exports = {
 
         const profile = await this._loadProfileAsync(profileName);
         const loginUrl = await this._createLoginUrlAsync(profile.azure_app_id_uri, profile.azure_tenant_id);
-        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, profile.azure_default_username, profile.azure_default_password);
+        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, profile.azure_default_username, profile.azure_default_password);
         const roles = this._parseRolesFromSamlResponse(samlResponse);
         const { role, durationHours } = await this._askUserForRoleAndDurationAsync(roles, noPrompt, profile.azure_default_role_arn, profile.azure_default_duration_hours);
-        await this._assumeRoleAsync(profileName, samlResponse, role, durationHours);
+        await this._assumeRoleAsync(profileName, samlResponse, role, durationHours, awsNoVerifySsl);
     },
 
     /**
@@ -363,12 +357,13 @@ module.exports = {
      * @returns {Promise.<string>} The SAML response.
      * @private
      */
-    async _performLoginAsync(url, headless, disableSandbox, cliProxy, noPrompt, defaultUsername, defaultPassword) {
+    async _performLoginAsync(url, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, defaultUsername, defaultPassword) {
         debug("Loading login page in Chrome");
         let browser;
         try {
             const args = headless ? [] : [`--app=${url}`, `--window-size=${WIDTH},${HEIGHT}`];
             if (disableSandbox) args.push('--no-sandbox');
+            if (enableChromeNetworkService) args.push('--enable-features=NetworkService');
 
             browser = await puppeteer.launch({
                 headless,
@@ -574,8 +569,20 @@ module.exports = {
      * @returns {Promise} A promise
      * @private
      */
-    async _assumeRoleAsync(profileName, assertion, role, durationHours) {
+    async _assumeRoleAsync(profileName, assertion, role, durationHours, awsNoVerifySsl) {
         console.log(`Assuming role ${role.roleArn}`);
+        if (process.env.https_proxy) {
+            AWS.config.update({
+                httpOptions: { agent: proxy(process.env.https_proxy) }
+            });
+        }else if(awsNoVerifySsl) {
+             const opt = { rejectUnauthorized: false };
+             opt.agent = new https.Agent(opt);
+             AWS.config.update({
+                 httpOptions: opt
+             });
+        }
+        const sts = new AWS.STS();
         const res = await sts.assumeRoleWithSAML({
             PrincipalArn: role.principalArn,
             RoleArn: role.roleArn,


### PR DESCRIPTION
Hello,
We are using this tool from a corporate network and have two issues:

- At some point a 30X redirect happens in the authentication process with our company website, entering password and only with Chromium's Network Service is the 30X honored. If not present the Username screen in Chromium never redirects.

- Our corporate network has SSL decrypt proxies in place. For this and other similar SSL issues the aws cli has the --no-verify-ssl option.  Added a similar option as well.

