### PR TITLE
Enable cookie auth/Stay logged in

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ You'll need your Azure Tenant ID and the App ID URI. To configure a named profil
 
     aws-azure-login --configure --profile foo
 
+#### Staying logged in, skip username/password for future logins
+
+During the configuration you can decide to stay logged in:
+
+    ? Stay logged in: skip authentication while refreshing aws credentials (true|false) (false)
+
+If you set this configuration to true, the usual authentication with username/password/MFA is skipped as it's using session cookies to remember your identity. This enables you to use `--no-prompt` without the need to store your password anywhere, it's an alternative for using environment variables as described below.
+As soon as you went through the full login procedure once, you can just use:
+
+    aws-azure-login --no-prompt
+
+or
+
+    aws-azure-login --profile foo --no-prompt
+
+to refresh your aws credentials.
+
+
 #### Environment Variables
 
 You can optionally store your responses as environment variables:

--- a/lib/configureProfileAsync.js
+++ b/lib/configureProfileAsync.js
@@ -22,13 +22,21 @@ module.exports = async profileName => {
         message: "Default Username:",
         default: profile && profile.azure_default_username
     }, {
+        name: "rememberMe",
+        message: "Stay logged in: skip authentication while refreshing aws credentials (true|false)",
+        default: (profile && profile.azure_default_remember_me.toString()) || 'false',
+        validate(input) {
+            if (input === 'true' || input === 'false') return true;
+            return 'Remember me must be either true or false';
+        }
+    }, {
         name: "defaultRoleArn",
         message: "Default Role ARN (if multiple):",
         default: profile && profile.azure_default_role_arn
     }, {
         name: "defaultDurationHours",
         message: "Default Session Duration Hours (up to 12):",
-        default: profile && profile.azure_default_duration_hours || 1,
+        default: (profile && profile.azure_default_duration_hours) || 1,
         validate(input) {
             input = Number(input);
             if (input > 0 && input <= 12) return true;
@@ -41,7 +49,8 @@ module.exports = async profileName => {
         azure_app_id_uri: answers.appIdUri,
         azure_default_username: answers.username,
         azure_default_role_arn: answers.defaultRoleArn,
-        azure_default_duration_hours: answers.defaultDurationHours
+        azure_default_duration_hours: answers.defaultDurationHours,
+        azure_default_remember_me: answers.rememberMe
     });
 
     console.log('Profile saved.');

--- a/lib/login.js
+++ b/lib/login.js
@@ -1,9 +1,12 @@
 "use strict";
 
 const _ = require("lodash");
+const os = require("os");
+const path = require("path");
 const Bluebird = require("bluebird");
 const inquirer = require("inquirer");
 const zlib = Bluebird.promisifyAll(require("zlib"));
+const mkdirpAsync = Bluebird.promisify(require("mkdirp"));
 const AWS = require("aws-sdk");
 const cheerio = require("cheerio");
 const uuid = require("uuid");
@@ -18,6 +21,11 @@ const WIDTH = 425;
 const HEIGHT = 550;
 const DELAY_ON_UNRECOGNIZED_PAGE = 1000;
 const MAX_UNRECOGNIZED_PAGE_DELAY = 30 * 1000;
+
+const awsDir = path.join(os.homedir(), ".aws");
+const paths = {
+    chromium: path.join(awsDir, "chromium")
+};
 
 if (process.env.https_proxy) {
     AWS.config.update({
@@ -227,9 +235,14 @@ const states = [
     {
         name: "Remember me",
         selector: `#KmsiDescription`,
-        async handler(page) {
-            debug("Clicking don't remember button");
-            await page.click("#idBtn_Back");
+        async handler(page, _selected, _noPrompt, _defaultUsername, _defaultPassword, rememberMe) {
+            if (rememberMe) {
+                debug("Clicking remember me button");
+                await page.click("#idSIButton9");
+            } else {
+                debug("Clicking don't remember button");
+                await page.click("#idBtn_Back");
+            }
 
             debug("Waiting for a delay");
             await Bluebird.delay(500);
@@ -263,7 +276,7 @@ module.exports = {
 
         const profile = await this._loadProfileAsync(profileName);
         const loginUrl = await this._createLoginUrlAsync(profile.azure_app_id_uri, profile.azure_tenant_id);
-        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, profile.azure_default_username, profile.azure_default_password);
+        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, profile.azure_default_username, profile.azure_default_password, profile.azure_default_remember_me);
         const roles = this._parseRolesFromSamlResponse(samlResponse);
         const { role, durationHours } = await this._askUserForRoleAndDurationAsync(roles, noPrompt, profile.azure_default_role_arn, profile.azure_default_duration_hours);
         await this._assumeRoleAsync(profileName, samlResponse, role, durationHours);
@@ -360,15 +373,21 @@ module.exports = {
      * @param {bool} [noPrompt] - Enable skipping of user prompting
      * @param {string} [defaultUsername] - The default username
      * @param {string} [defaultPassword] - The default password
+     * @param {bool} [rememberMe] - Enable remembering the session
      * @returns {Promise.<string>} The SAML response.
      * @private
      */
-    async _performLoginAsync(url, headless, disableSandbox, cliProxy, noPrompt, defaultUsername, defaultPassword) {
+    async _performLoginAsync(url, headless, disableSandbox, cliProxy, noPrompt, defaultUsername, defaultPassword, rememberMe) {
         debug("Loading login page in Chrome");
+
         let browser;
         try {
             const args = headless ? [] : [`--app=${url}`, `--window-size=${WIDTH},${HEIGHT}`];
             if (disableSandbox) args.push('--no-sandbox');
+            if (rememberMe) {
+                await mkdirpAsync(paths.chromium);
+                args.push(`--user-data-dir=${paths.chromium}`);
+            }
 
             browser = await puppeteer.launch({
                 headless,
@@ -396,7 +415,6 @@ module.exports = {
                             contentType: 'text/plain',
                             body: ''
                         });
-                        browser.close();
                     } else {
                         req.continue();
                     }
@@ -438,7 +456,7 @@ module.exports = {
 
                             await Promise.race([
                                 samlResponsePromise,
-                                state.handler(page, selected, noPrompt, defaultUsername, defaultPassword)
+                                state.handler(page, selected, noPrompt, defaultUsername, defaultPassword, rememberMe)
                             ]);
 
                             debug(`Finished state: ${state.name}`);


### PR DESCRIPTION
Hi,

I'd like to add the functionality to use the --user-data-dir option to persist the browser data.
This enables the usage of cookies to skip the authentication as long as the cookie is valid.

As a result, credential refresh should be much smoother.

Let me know your thoughts.

Best regards
Lars