### PR TITLE
Add Expiration to aid in client-side scripting

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -582,11 +582,11 @@ module.exports = {
             SAMLAssertion: assertion,
             DurationSeconds: Math.round(durationHours * 60 * 60)
         }).promise();
-
         await awsConfig.setProfileCredentialsAsync(profileName, {
             aws_access_key_id: res.Credentials.AccessKeyId,
             aws_secret_access_key: res.Credentials.SecretAccessKey,
-            aws_session_token: res.Credentials.SessionToken
+            aws_session_token: res.Credentials.SessionToken,
+            aws_session_expiration: res.Credentials.Expiration.toJSON()
         });
     }
 };


### PR DESCRIPTION
It would be easier to build scripts that may need to renew the session if they could easily check if the session is expired without having to keep track of the duration themselves. So this PR simply adds the expiration field in the assumeRoleWithSAML response with the other information into ~/.aws/credentials