### PR TITLE
Enable auto refresh & stay logged in feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,21 @@ _Note:_ on Linux you will likely need to disable the Puppeteer sandbox or Chrome
 
 If behind corporate proxy, then just set https\_proxy env variable.
 
+## Automation
+
+### Renew credentials for all configured profiles
+
+You can renew credentials for all configured profiles in one run. This is especially useful, if the maximum session length on AWS side is configured to a low value due to security constraints. Just run:
+
+    aws-azure-login --all-profiles
+
+If you configure all profiles to stay logged in, you can easily skip the prompts:
+
+    aws-azure-login --all-profiles --no-prompt
+
+This will allow you to automate the credentials refresh procedure, eg. by running a cronjob every 5 minutes.
+To skip unnecessary calls, the credentials are only getting refreshed if the time to expire is lower than 11 minutes.
+
 ## Getting Your Tenant ID and App ID URI
 
 Your Azure AD system admin should be able to provide you with your Tenant ID and App ID URI. If you can't get it from them, you can scrape it from a login page from the myapps.microsoft.com page.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ To use aws-azure-login with AWS GovCloud, set the `region` profile property in y
 * us-gov-west-1
 * us-gov-east-1
 
+#### Staying logged in, skip username/password for future logins
+
+During the configuration you can decide to stay logged in:
+
+    ? Stay logged in: skip authentication while refreshing aws credentials (true|false) (false)
+
+If you set this configuration to true, the usual authentication with username/password/MFA is skipped as it's using session cookies to remember your identity. This enables you to use `--no-prompt` without the need to store your password anywhere, it's an alternative for using environment variables as described below.
+As soon as you went through the full login procedure once, you can just use:
+
+    aws-azure-login --no-prompt
+
+or
+
+    aws-azure-login --profile foo --no-prompt
+
+to refresh your aws credentials.
+
 #### Environment Variables
 
 You can optionally store your responses as environment variables:

--- a/bin/index.js
+++ b/bin/index.js
@@ -35,7 +35,7 @@ const forceRefresh = commander.forceRefresh;
 if (commander.allProfiles) {
     Promise.resolve()
         .then(() => {
-            return login.loginAll(mode, disableSandbox, noPrompt, forceRefresh);
+            return login.loginAll(mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso, forceRefresh);
         })
         .catch(err => {
             if (err.name === "CLIError") {

--- a/bin/index.js
+++ b/bin/index.js
@@ -11,9 +11,10 @@ const configureProfileAsync = require("../lib/configureProfileAsync");
 const login = require("../lib/login");
 
 commander
-    .option("--profile <name>", "The name of the profile to log in with (or configure)")
-    .option("--configure", "Configure the profile")
-    .option("--mode <mode>", "'cli' to hide the login page and perform the login through the CLI (default behavior), 'gui' to perform the login through the Azure GUI (more reliable but only works on GUI operating system), 'debug' to show the login page but perform the login through the CLI (useful to debug issues with the CLI login)")
+    .option("-p, --profile <name>", "The name of the profile to log in with (or configure)")
+    .option("-a, --all-profiles", "Run for all configured profiles")
+    .option("-c, --configure", "Configure the profile")
+    .option("-m, --mode <mode>", "'cli' to hide the login page and perform the login through the CLI (default behavior), 'gui' to perform the login through the Azure GUI (more reliable but only works on GUI operating system), 'debug' to show the login page but perform the login through the CLI (useful to debug issues with the CLI login)")
     .option("--no-sandbox", "Disable the Puppeteer sandbox (usually necessary on Linux)")
     .option("--no-prompt", "Do not prompt for input and accept the default choice", false)
     .option("--enable-chrome-network-service", "Enable Chromium's Network Service (needed when login provider redirects with 3XX)")
@@ -29,16 +30,32 @@ const enableChromeNetworkService = commander.enableChromeNetworkService;
 const awsNoVerifySsl = !commander.verifySsl;
 const enableChromeSeamlessSso = commander.enableChromeSeamlessSso;
 
-Promise.resolve()
-    .then(() => {
-        if (commander.configure) return configureProfileAsync(profileName);
-        return login.loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso);
-    })
-    .catch(err => {
-        if (err.name === "CLIError") {
-            console.error(err.message);
-            process.exit(2);
-        } else {
-            console.log(err);
-        }
-    });
+if (commander.allProfiles) {
+    Promise.resolve()
+        .then(() => {
+            return login.loginAll(mode, disableSandbox, noPrompt);
+        })
+        .catch(err => {
+            if (err.name === "CLIError") {
+                console.error(err.message);
+                process.exit(2);
+            } else {
+                console.log(err);
+            }
+        });
+} else {
+    Promise.resolve()
+        .then(() => {
+            if (commander.configure) return configureProfileAsync(profileName);
+            return login.loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso);
+        })
+        .catch(err => {
+            if (err.name === "CLIError") {
+                console.error(err.message);
+                process.exit(2);
+            } else {
+                console.log(err);
+            }
+        });
+}
+

--- a/bin/index.js
+++ b/bin/index.js
@@ -32,32 +32,21 @@ const awsNoVerifySsl = !commander.verifySsl;
 const enableChromeSeamlessSso = commander.enableChromeSeamlessSso;
 const forceRefresh = commander.forceRefresh;
 
-if (commander.allProfiles) {
-    Promise.resolve()
-        .then(() => {
-            return login.loginAll(mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso, forceRefresh);
-        })
-        .catch(err => {
-            if (err.name === "CLIError") {
-                console.error(err.message);
-                process.exit(2);
-            } else {
-                console.log(err);
-            }
-        });
-} else {
-    Promise.resolve()
-        .then(() => {
-            if (commander.configure) return configureProfileAsync(profileName);
-            return login.loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso);
-        })
-        .catch(err => {
-            if (err.name === "CLIError") {
-                console.error(err.message);
-                process.exit(2);
-            } else {
-                console.log(err);
-            }
-        });
-}
 
+Promise.resolve()
+    .then(() => {
+        if (commander.allProfiles) {
+            return login.loginAll(mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso, forceRefresh);
+        }
+
+        if (commander.configure) return configureProfileAsync(profileName);
+        return login.loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso);
+    })
+    .catch(err => {
+        if (err.name === "CLIError") {
+            console.error(err.message);
+            process.exit(2);
+        } else {
+            console.log(err);
+        }
+    });

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,6 +13,7 @@ const login = require("../lib/login");
 commander
     .option("-p, --profile <name>", "The name of the profile to log in with (or configure)")
     .option("-a, --all-profiles", "Run for all configured profiles")
+    .option("-f, --force-refresh", "Force a credential refresh, even if they are still valid")
     .option("-c, --configure", "Configure the profile")
     .option("-m, --mode <mode>", "'cli' to hide the login page and perform the login through the CLI (default behavior), 'gui' to perform the login through the Azure GUI (more reliable but only works on GUI operating system), 'debug' to show the login page but perform the login through the CLI (useful to debug issues with the CLI login)")
     .option("--no-sandbox", "Disable the Puppeteer sandbox (usually necessary on Linux)")
@@ -29,11 +30,12 @@ const noPrompt = !commander.prompt;
 const enableChromeNetworkService = commander.enableChromeNetworkService;
 const awsNoVerifySsl = !commander.verifySsl;
 const enableChromeSeamlessSso = commander.enableChromeSeamlessSso;
+const forceRefresh = commander.forceRefresh;
 
 if (commander.allProfiles) {
     Promise.resolve()
         .then(() => {
-            return login.loginAll(mode, disableSandbox, noPrompt);
+            return login.loginAll(mode, disableSandbox, noPrompt, forceRefresh);
         })
         .catch(err => {
             if (err.name === "CLIError") {

--- a/lib/awsConfig.js
+++ b/lib/awsConfig.js
@@ -15,7 +15,7 @@ const paths = {
     credentials: process.env.AWS_SHARED_CREDENTIALS_FILE || path.join(awsDir, "credentials")
 };
 
-//Autorefresh credential time limit in minutes
+// Autorefresh credential time limit in minutes
 const refreshLimit = 11;
 
 module.exports = {
@@ -48,7 +48,7 @@ module.exports = {
         }
 
         const timeDifference = expirationDate - new Date();
-        debug(`Remaining time till credential expiration: ${timeDifference/1000}s, refresh due if time lower than: ${refreshLimitInMs/1000}s`)
+        debug(`Remaining time till credential expiration: ${timeDifference / 1000}s, refresh due if time lower than: ${refreshLimitInMs / 1000}s`);
         return (timeDifference < refreshLimitInMs);
     },
 
@@ -64,7 +64,7 @@ module.exports = {
         debug(`Getting all configured profiles from config.`);
         const config = await this._loadAsync("config");
 
-        const profiles = Object.keys(config).map(function(e) {
+        const profiles = Object.keys(config).map(function (e) {
             return e.replace("profile ", "");
         });
         debug(`Received profiles: ${profiles.toString()}`);

--- a/lib/awsConfig.js
+++ b/lib/awsConfig.js
@@ -15,6 +15,9 @@ const paths = {
     credentials: process.env.AWS_SHARED_CREDENTIALS_FILE || path.join(awsDir, "credentials")
 };
 
+//Autorefresh credential time limit in minutes
+const refreshLimit = 11;
+
 module.exports = {
     async setProfileConfigValuesAsync(profileName, values) {
         const sectionName = profileName === "default" ? "default" : `profile ${profileName}`;
@@ -32,12 +35,33 @@ module.exports = {
         return config[sectionName];
     },
 
+    async isProfileAboutToExpireAsync(profileName) {
+        debug(`Getting credentials for profile '${profileName}'`);
+        const config = await this._loadAsync("credentials");
+        const refreshLimitInMs = refreshLimit * 60 * 1000;
+
+        const timeDifference = Date.parse(config[profileName].aws_expiration) - new Date();
+        debug(`Remaining time till credential expiration: ${timeDifference/1000}s, refresh due if time lower than: ${refreshLimitInMs/1000}s`)
+        return (timeDifference < refreshLimitInMs);
+    },
+
     async setProfileCredentialsAsync(profileName, values) {
         const credentials = await this._loadAsync("credentials");
 
         debug(`Setting credentials for profile '${profileName}'`);
         credentials[profileName] = values;
         await this._saveAsync("credentials", credentials);
+    },
+
+    async getAllProfileNames() {
+        debug(`Getting all configured profiles from config.`);
+        const config = await this._loadAsync("config");
+
+        const profiles = Object.keys(config).map(function(e) {
+            return e.replace("profile ", "");
+        });
+        debug(`Received profiles: ${profiles.toString()}`);
+        return profiles;
     },
 
     async _loadAsync(type) {

--- a/lib/awsConfig.js
+++ b/lib/awsConfig.js
@@ -1,19 +1,12 @@
 "use strict";
 
-const os = require("os");
-const path = require("path");
 const ini = require("ini");
 const _ = require("lodash");
 const Bluebird = require("bluebird");
 const debug = require("debug")('aws-azure-login');
 const fs = Bluebird.promisifyAll(require("fs"));
 const mkdirpAsync = Bluebird.promisify(require("mkdirp"));
-
-const awsDir = path.join(os.homedir(), ".aws");
-const paths = {
-    config: process.env.AWS_CONFIG_FILE || path.join(awsDir, "config"),
-    credentials: process.env.AWS_SHARED_CREDENTIALS_FILE || path.join(awsDir, "credentials")
-};
+const paths = require("./paths");
 
 // Autorefresh credential time limit in milliseconds
 const refreshLimitInMs = 11 * 60 * 1000;
@@ -97,8 +90,8 @@ module.exports = {
         debug(`Stringifying ${type} INI data`);
         const text = ini.stringify(data);
 
-        debug(`Creating AWS config directory '${awsDir}' if not exists.`);
-        await mkdirpAsync(awsDir);
+        debug(`Creating AWS config directory '${paths.awsDir}' if not exists.`);
+        await mkdirpAsync(paths.awsDir);
 
         debug(`Writing '${type}' INI to file '${paths[type]}'`);
         await fs.writeFileAsync(paths[type], text);

--- a/lib/awsConfig.js
+++ b/lib/awsConfig.js
@@ -39,8 +39,15 @@ module.exports = {
         debug(`Getting credentials for profile '${profileName}'`);
         const config = await this._loadAsync("credentials");
         const refreshLimitInMs = refreshLimit * 60 * 1000;
+        let expirationDate;
 
-        const timeDifference = Date.parse(config[profileName].aws_expiration) - new Date();
+        if (config[profileName] === undefined || config[profileName].aws_expiration === undefined) {
+            expirationDate = new Date();
+        } else {
+            expirationDate = Date.parse(config[profileName].aws_expiration);
+        }
+
+        const timeDifference = expirationDate - new Date();
         debug(`Remaining time till credential expiration: ${timeDifference/1000}s, refresh due if time lower than: ${refreshLimitInMs/1000}s`)
         return (timeDifference < refreshLimitInMs);
     },

--- a/lib/awsConfig.js
+++ b/lib/awsConfig.js
@@ -15,8 +15,8 @@ const paths = {
     credentials: process.env.AWS_SHARED_CREDENTIALS_FILE || path.join(awsDir, "credentials")
 };
 
-// Autorefresh credential time limit in minutes
-const refreshLimit = 11;
+// Autorefresh credential time limit in milliseconds
+const refreshLimitInMs = 11 * 60 * 1000;
 
 module.exports = {
     async setProfileConfigValuesAsync(profileName, values) {
@@ -38,7 +38,6 @@ module.exports = {
     async isProfileAboutToExpireAsync(profileName) {
         debug(`Getting credentials for profile '${profileName}'`);
         const config = await this._loadAsync("credentials");
-        const refreshLimitInMs = refreshLimit * 60 * 1000;
         let expirationDate;
 
         if (config[profileName] === undefined || config[profileName].aws_expiration === undefined) {
@@ -100,7 +99,7 @@ module.exports = {
 
         debug(`Creating AWS config directory '${awsDir}' if not exists.`);
         await mkdirpAsync(awsDir);
-        
+
         debug(`Writing '${type}' INI to file '${paths[type]}'`);
         await fs.writeFileAsync(paths[type], text);
     }

--- a/lib/configureProfileAsync.js
+++ b/lib/configureProfileAsync.js
@@ -22,6 +22,14 @@ module.exports = async profileName => {
         message: "Default Username:",
         default: profile && profile.azure_default_username
     }, {
+        name: "rememberMe",
+        message: "Stay logged in: skip authentication while refreshing aws credentials (true|false)",
+        default: (profile && profile.azure_default_remember_me.toString()) || 'false',
+        validate(input) {
+            if (input === 'true' || input === 'false') return true;
+            return 'Remember me must be either true or false';
+        }
+    }, {
         name: "defaultRoleArn",
         message: "Default Role ARN (if multiple):",
         default: profile && profile.azure_default_role_arn
@@ -41,7 +49,8 @@ module.exports = async profileName => {
         azure_app_id_uri: answers.appIdUri,
         azure_default_username: answers.username,
         azure_default_role_arn: answers.defaultRoleArn,
-        azure_default_duration_hours: answers.defaultDurationHours
+        azure_default_duration_hours: answers.defaultDurationHours,
+        azure_default_remember_me: answers.rememberMe
     });
 
     console.log('Profile saved.');

--- a/lib/configureProfileAsync.js
+++ b/lib/configureProfileAsync.js
@@ -24,7 +24,7 @@ module.exports = async profileName => {
     }, {
         name: "rememberMe",
         message: "Stay logged in: skip authentication while refreshing aws credentials (true|false)",
-        default: (profile && profile.azure_default_remember_me.toString()) || 'false',
+        default: (profile && profile.azure_default_remember_me && profile.azure_default_remember_me.toString()) || 'false',
         validate(input) {
             if (input === 'true' || input === 'false') return true;
             return 'Remember me must be either true or false';

--- a/lib/login.js
+++ b/lib/login.js
@@ -289,7 +289,7 @@ module.exports = {
         await this._assumeRoleAsync(profileName, samlResponse, role, durationHours, awsNoVerifySsl, profile.region);
     },
 
-    async loginAll(mode, disableSandbox, noPrompt, forceRefresh) {
+    async loginAll(mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso, forceRefresh) {
         const profiles = await awsConfig.getAllProfileNames();
 
         for (let profile of profiles) {
@@ -300,7 +300,7 @@ module.exports = {
             }
 
             debug(`Run login for profile: ${profile}`);
-            await this.loginAsync(profile, mode, disableSandbox, noPrompt);
+            await this.loginAsync(profile, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso);
         }
     },
 

--- a/lib/login.js
+++ b/lib/login.js
@@ -1,9 +1,12 @@
 "use strict";
 
 const _ = require("lodash");
+const os = require("os");
+const path = require("path");
 const Bluebird = require("bluebird");
 const inquirer = require("inquirer");
 const zlib = Bluebird.promisifyAll(require("zlib"));
+const mkdirpAsync = Bluebird.promisify(require("mkdirp"));
 const AWS = require("aws-sdk");
 const cheerio = require("cheerio");
 const uuid = require("uuid");
@@ -24,6 +27,10 @@ const MAX_UNRECOGNIZED_PAGE_DELAY = 30 * 1000;
 const AZURE_AD_SSO = "autologon.microsoftazuread-sso.com";
 const AWS_SAML_ENDPOINT = "https://signin.aws.amazon.com/saml";
 const AWS_GOV_SAML_ENDPOINT = "https://signin.amazonaws-us-gov.com/saml";
+const awsDir = path.join(os.homedir(), ".aws");
+const paths = {
+    chromium: path.join(awsDir, "chromium")
+};
 
 /**
  * To proxy the input/output of the Azure login page, it's easiest to run a loop that
@@ -228,9 +235,14 @@ const states = [
     {
         name: "Remember me",
         selector: `#KmsiDescription`,
-        async handler(page) {
-            debug("Clicking don't remember button");
-            await page.click("#idBtn_Back");
+        async handler(page, _selected, _noPrompt, _defaultUsername, _defaultPassword, rememberMe) {
+            if (rememberMe) {
+                debug("Clicking remember me button");
+                await page.click("#idSIButton9");
+            } else {
+                debug("Clicking don't remember button");
+                await page.click("#idBtn_Back");
+            }
 
             debug("Waiting for a delay");
             await Bluebird.delay(500);
@@ -271,7 +283,7 @@ module.exports = {
         console.log('Using AWS SAML endpoint', assertionConsumerServiceURL);
 
         const loginUrl = await this._createLoginUrlAsync(profile.azure_app_id_uri, profile.azure_tenant_id, assertionConsumerServiceURL);
-        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, profile.azure_default_username, profile.azure_default_password, enableChromeSeamlessSso);
+        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, profile.azure_default_username, profile.azure_default_password, enableChromeSeamlessSso, profile.azure_default_remember_me);
         const roles = this._parseRolesFromSamlResponse(samlResponse);
         const { role, durationHours } = await this._askUserForRoleAndDurationAsync(roles, noPrompt, profile.azure_default_role_arn, profile.azure_default_duration_hours);
         await this._assumeRoleAsync(profileName, samlResponse, role, durationHours, awsNoVerifySsl, profile.region);
@@ -372,11 +384,13 @@ module.exports = {
      * @param {string} [defaultUsername] - The default username
      * @param {string} [defaultPassword] - The default password
      * @param {bool} [enableChromeSeamlessSso] - chrome seamless SSO
+     * @param {bool} [rememberMe] - Enable remembering the session
      * @returns {Promise.<string>} The SAML response.
      * @private
      */
-    async _performLoginAsync(url, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, defaultUsername, defaultPassword, enableChromeSeamlessSso) {
+    async _performLoginAsync(url, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, defaultUsername, defaultPassword, enableChromeSeamlessSso, rememberMe) {
         debug("Loading login page in Chrome");
+
         let browser;
         try {
             const args = headless ? [] : [`--app=${url}`, `--window-size=${WIDTH},${HEIGHT}`];
@@ -386,6 +400,10 @@ module.exports = {
                 `--auth-server-whitelist=${AZURE_AD_SSO}`,
                 `--auth-negotiate-delegate-whitelist=${AZURE_AD_SSO}`
             );
+            if (rememberMe) {
+                await mkdirpAsync(paths.chromium);
+                args.push(`--user-data-dir=${paths.chromium}`);
+            }
 
             browser = await puppeteer.launch({
                 headless,
@@ -413,7 +431,6 @@ module.exports = {
                             contentType: 'text/plain',
                             body: ''
                         });
-                        browser.close();
                     } else {
                         req.continue();
                     }
@@ -455,7 +472,7 @@ module.exports = {
 
                             await Promise.race([
                                 samlResponsePromise,
-                                state.handler(page, selected, noPrompt, defaultUsername, defaultPassword)
+                                state.handler(page, selected, noPrompt, defaultUsername, defaultPassword, rememberMe)
                             ]);
 
                             debug(`Finished state: ${state.name}`);

--- a/lib/login.js
+++ b/lib/login.js
@@ -289,12 +289,12 @@ module.exports = {
         await this._assumeRoleAsync(profileName, samlResponse, role, durationHours, awsNoVerifySsl, profile.region);
     },
 
-    async loginAll(mode, disableSandbox, noPrompt) {
+    async loginAll(mode, disableSandbox, noPrompt, forceRefresh) {
         const profiles = await awsConfig.getAllProfileNames();
 
         for (let profile of profiles) {
             debug(`Check if profile ${profile} is expired or is about to expire`);
-            if (!await awsConfig.isProfileAboutToExpireAsync(profile)) {
+            if (!forceRefresh && !await awsConfig.isProfileAboutToExpireAsync(profile)) {
                 debug(`Profile ${profile} not yet due for refresh.`);
                 continue;
             }

--- a/lib/login.js
+++ b/lib/login.js
@@ -1,8 +1,6 @@
 "use strict";
 
 const _ = require("lodash");
-const os = require("os");
-const path = require("path");
 const Bluebird = require("bluebird");
 const inquirer = require("inquirer");
 const zlib = Bluebird.promisifyAll(require("zlib"));
@@ -15,6 +13,7 @@ const querystring = require('querystring');
 const debug = require("debug")('aws-azure-login');
 const CLIError = require("./CLIError");
 const awsConfig = require("./awsConfig");
+const paths = require("./paths");
 const proxy = require('proxy-agent');
 const https = require('https');
 
@@ -27,10 +26,6 @@ const MAX_UNRECOGNIZED_PAGE_DELAY = 30 * 1000;
 const AZURE_AD_SSO = "autologon.microsoftazuread-sso.com";
 const AWS_SAML_ENDPOINT = "https://signin.aws.amazon.com/saml";
 const AWS_GOV_SAML_ENDPOINT = "https://signin.amazonaws-us-gov.com/saml";
-const awsDir = path.join(os.homedir(), ".aws");
-const paths = {
-    chromium: path.join(awsDir, "chromium")
-};
 
 /**
  * To proxy the input/output of the Azure login page, it's easiest to run a loop that

--- a/lib/login.js
+++ b/lib/login.js
@@ -292,7 +292,7 @@ module.exports = {
     async loginAll(mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso, forceRefresh) {
         const profiles = await awsConfig.getAllProfileNames();
 
-        for (let profile of profiles) {
+        for (const profile of profiles) {
             debug(`Check if profile ${profile} is expired or is about to expire`);
             if (!forceRefresh && !await awsConfig.isProfileAboutToExpireAsync(profile)) {
                 debug(`Profile ${profile} not yet due for refresh.`);
@@ -446,6 +446,8 @@ module.exports = {
                             contentType: 'text/plain',
                             body: ''
                         });
+                        browser.close();
+                        debug(`Received SAML response, browser closed`);
                     } else {
                         req.continue();
                     }
@@ -455,12 +457,18 @@ module.exports = {
             debug("Enabling request interception");
             await page.setRequestInterception(true);
 
-            if ((headless) || (!headless && cliProxy)) {
-                debug("Going to login page");
-                await page.goto(url, { waitUntil: 'domcontentloaded' });
-            } else {
-                debug("Waiting for login page to load");
-                await page.waitForNavigation({ waitUntil: 'networkidle0' });
+            try {
+                if ((headless) || (!headless && cliProxy)) {
+                    debug("Going to login page");
+                    await page.goto(url, { waitUntil: 'domcontentloaded' });
+                } else {
+                    debug("Waiting for login page to load");
+                    await page.waitForNavigation({ waitUntil: 'networkidle0' });
+                }
+            } catch (err) {
+                // An error will be thrown if you're still logged in cause the page.goto ot waitForNavigation
+                // will be a redirect to AWS. That's usually OK
+                debug(`Error occured during loading the first page: ${err.message}`);
             }
 
             if (cliProxy) {
@@ -591,6 +599,7 @@ module.exports = {
         }
 
         if (noPrompt && defaultDurationHours) {
+            debug("Default durationHours found. No need to ask.");
             durationHours = defaultDurationHours;
         } else {
             questions.push({
@@ -606,9 +615,13 @@ module.exports = {
             });
         }
 
-        const answers = await inquirer.prompt(questions);
-        if (!role) role = _.find(roles, ["roleArn", answers.role]);
-        if (!durationHours) durationHours = answers.durationHours;
+        // Don't prompt for questions if not needed, an unneeded TTYWRAP prevents node from exiting when
+        // user is logged in and using multiple profiles --all-profiles and --no-prompt
+        if (questions.length > 0) {
+            const answers = await inquirer.prompt(questions);
+            if (!role) role = _.find(roles, ["roleArn", answers.role]);
+            if (!durationHours) durationHours = answers.durationHours;
+        }
         return { role, durationHours };
     },
 

--- a/lib/login.js
+++ b/lib/login.js
@@ -289,6 +289,21 @@ module.exports = {
         await this._assumeRoleAsync(profileName, samlResponse, role, durationHours, awsNoVerifySsl, profile.region);
     },
 
+    async loginAll(mode, disableSandbox, noPrompt) {
+        const profiles = await awsConfig.getAllProfileNames();
+
+        for (let profile of profiles) {
+            debug(`Check if profile ${profile} is expired or is about to expire`);
+            if (!await awsConfig.isProfileAboutToExpireAsync(profile)) {
+                debug(`Profile ${profile} not yet due for refresh.`);
+                continue;
+            }
+
+            debug(`Run login for profile: ${profile}`);
+            await this.loginAsync(profile, mode, disableSandbox, noPrompt);
+        }
+    },
+
     /**
      * Gather data from environment variables
      * @returns {string} Object of environment variables
@@ -641,7 +656,7 @@ module.exports = {
             aws_access_key_id: res.Credentials.AccessKeyId,
             aws_secret_access_key: res.Credentials.SecretAccessKey,
             aws_session_token: res.Credentials.SessionToken,
-            aws_session_expiration: res.Credentials.Expiration.toJSON()
+            aws_expiration: res.Credentials.Expiration.toISOString()
         });
     }
 };

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const os = require("os");
+const path = require("path");
+
+const awsDir = path.join(os.homedir(), ".aws");
+
+module.exports = {
+    awsDir,
+    config: process.env.AWS_CONFIG_FILE || path.join(awsDir, "config"),
+    credentials: process.env.AWS_SHARED_CREDENTIALS_FILE || path.join(awsDir, "credentials"),
+    chromium: path.join(awsDir, "chromium")
+};


### PR DESCRIPTION
Hi,

I'd like to add 2 features:

- The functionality to use the --user-data-dir option to persist the browser data.
This enables the usage of cookies to skip the authentication as long as the cookie is valid.
As a result, credential refresh should be much smoother. This is also a requirement for the second feature I'd like to add.
- The second feature I'd like to add is the possibility to refresh all profiles with only one command. This will allow you to stay logged in while working with AWS, even if the maximum allowed session lifetime is configured to a low value on AWS side (eg. due to security constraints within a company).

Let me know your thoughts.

Best regards
Lars