### PR TITLE
Support for logging into multiple profiles at once (--regex option).

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ _Note:_ on Linux you will likely need to disable the Puppeteer sandbox or Chrome
 
     aws-azure-login --no-sandbox
 
+### Logging In To Multiple Profiles
+
+Adding the option --regex treats the profile name as a regex pattern - each matching profile will be assumed. People that work with many accounts or profiles and need to operate across them may find this useful.
+
 ### Behind corporate proxy
 
 If behind corporate proxy, then just set https\_proxy env variable.

--- a/bin/index.js
+++ b/bin/index.js
@@ -13,6 +13,7 @@ const login = require("../lib/login");
 
 commander
     .option("--profile <name>", "The name of the profile to log in with (or configure)")
+    .option("--regex", "Use profile <name> as a regular expression and login to all matching profiles.")
     .option("--configure", "Configure the profile")
     .option("--mode <mode>", "'cli' to hide the login page and perform the login through the CLI (default behavior), 'gui' to perform the login through the Azure GUI (more reliable but only works on GUI operating system), 'debug' to show the login page but perform the login through the CLI (useful to debug issues with the CLI login)")
     .option("--no-sandbox", "Disable the Puppeteer sandbox (usually necessary on Linux)")
@@ -27,11 +28,12 @@ const disableSandbox = !commander.sandbox;
 const noPrompt = !commander.prompt;
 const enableChromeNetworkService = commander.enableChromeNetworkService;
 const awsNoVerifySsl = !commander.verifySsl;
+const isRegex = commander.regex;
 
 Promise.resolve()
     .then(() => {
         if (commander.configure) return configureProfileAsync(profileName);
-        return login.loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl);
+        return login.loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, isRegex);
     })
     .catch(err => {
         if (err.name === "CLIError") {

--- a/lib/awsConfig.js
+++ b/lib/awsConfig.js
@@ -32,9 +32,20 @@ module.exports = {
         return config[sectionName];
     },
 
+    async getProfileNamesAsync() {
+        let profiles = [];
+        debug('Getting profile names');
+        const config = await this._loadAsync("config");
+        for (var c_section in config) {
+            if (config.hasOwnProperty(c_section)) {
+                profiles.push(c_section.replace(/^profile\s+/,''));
+            }
+        }
+        return profiles;
+    },
+
     async setProfileCredentialsAsync(profileName, values) {
         const credentials = await this._loadAsync("credentials");
-
         debug(`Setting credentials for profile '${profileName}'`);
         credentials[profileName] = values;
         await this._saveAsync("credentials", credentials);

--- a/lib/login.js
+++ b/lib/login.js
@@ -240,7 +240,7 @@ const states = [
 ];
 
 module.exports = {
-    async loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl) {
+    async loginAsync(profilePattern, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, profileRegex) {
         let headless, cliProxy;
         if (mode === 'cli') {
             headless = true;
@@ -255,12 +255,50 @@ module.exports = {
             throw new CLIError('Invalid mode');
         }
 
-        const profile = await this._loadProfileAsync(profileName);
-        const loginUrl = await this._createLoginUrlAsync(profile.azure_app_id_uri, profile.azure_tenant_id);
-        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, profile.azure_default_username, profile.azure_default_password);
-        const roles = this._parseRolesFromSamlResponse(samlResponse);
-        const { role, durationHours } = await this._askUserForRoleAndDurationAsync(roles, noPrompt, profile.azure_default_role_arn, profile.azure_default_duration_hours);
-        await this._assumeRoleAsync(profileName, samlResponse, role, durationHours, awsNoVerifySsl);
+        const profiles = await awsConfig.getProfileNamesAsync();
+        debug(`found profiles ${profiles}`);
+
+        let matched_profiles = [];
+        for (let profile of profiles) {
+            if ((!profileRegex && (profile == profilePattern)) 
+                || (profileRegex && profile.match(profilePattern))) {
+                matched_profiles.push({ 'name' : profile, 'def' : await this._loadProfileAsync(profile)});
+            }
+        }
+        debug(`matched ${matched_profiles.length} profiles`);
+
+        if (!matched_profiles.length) {
+            if (profileRegex) {
+                throw new CLIError(`No profiles matched pattern '${profilePattern}'. You must configure profiles first with --configure.`);
+            } else {
+                throw new CLIError(`Unknown profile '${profilePattern}'. You must configure it first with --configure.`);
+            }
+        }
+
+        matched_profiles = _.groupBy(matched_profiles,function(_prof){return _prof['def'].azure_app_id_uri + ' ' + _prof['def'].azure_tenant_id;});
+        debug(`mappped to ${Object.keys(matched_profiles).length} identities`);
+
+        for (let identity in matched_profiles) {
+            const profiles = matched_profiles[identity];  
+            let loginUrl, samlResponse, roles;
+            debug(`login for identity ${identity}`);
+            for (const profile of profiles) {
+                debug(`login for profile ${profile['name']}`);
+
+                if (loginUrl === undefined) 
+                    loginUrl = await this._createLoginUrlAsync(profile['def'].azure_app_id_uri, profile['def'].azure_tenant_id);
+
+                if (samlResponse === undefined) 
+                    samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, profile['def'].azure_default_username, profile['def'].azure_default_password);
+                    
+                if (roles === undefined) 
+                    roles = this._parseRolesFromSamlResponse(samlResponse);
+
+                const { role, durationHours } = await this._askUserForRoleAndDurationAsync(roles, true, profile['def'].azure_default_role_arn, profile['def'].azure_default_duration_hours);
+                await this._assumeRoleAsync(profile['name'], samlResponse, role, durationHours, awsNoVerifySsl);
+            }
+        }
+
     },
 
     /**


### PR DESCRIPTION
Hi - I work in an organisation with many aws accounts and regularly need to assume many roles in a short space of time. To make this easier and faster, I've modified aws-azure-login to support logging into multiple profiles at once by adding a --regex option. This option treats the --profile parameter as a regular expression and then attempts to assume-role for each matched profile. The AzAD auth happens once per identity, followed by one or more assume-roles. Hoping that you can consider this for inclusion. This is my first ever collaboration on github - hopefully I'm going about it the right way. 