### PR TITLE
Config/Credentials files can located by environment variables

### DIFF
--- a/lib/awsConfig.js
+++ b/lib/awsConfig.js
@@ -11,8 +11,8 @@ const mkdirpAsync = Bluebird.promisify(require("mkdirp"));
 
 const awsDir = path.join(os.homedir(), ".aws");
 const paths = {
-    config: path.join(awsDir, "config"),
-    credentials: path.join(awsDir, "credentials")
+    config: process.env.AWS_CONFIG_FILE || path.join(awsDir, "config"),
+    credentials: process.env.AWS_SHARED_CREDENTIALS_FILE || path.join(awsDir, "credentials")
 };
 
 module.exports = {


### PR DESCRIPTION
Hello,

I like to separate my configuration files using environment variables (see https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html) - I tend to do this to keep configuration from different client accounts away from the configuration of my personal AWS accounts. 

It seems like it's only a minor change to allow this. Let me know if you would need me to do anything further to get this merged.

Cheers