### PR TITLE
Add Chromium flag for SPNEGO/Kerberos

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -19,6 +19,7 @@ commander
     .option("--no-prompt", "Do not prompt for input and accept the default choice", false)
     .option("--enable-chrome-network-service", "Enable Chromium's Network Service (needed when login provider redirects with 3XX)")
     .option("--no-verify-ssl", "Disable SSL Peer Verification for connections to AWS (no effect if behind proxy)")
+    .option("--enable-chrome-seamless-sso", "Enable Chromium's pass-through authentication with Azure Active Directory Seamless Single Sign-On")
     .parse(process.argv);
 
 const profileName = commander.profile || process.env.AWS_PROFILE || "default";
@@ -27,11 +28,12 @@ const disableSandbox = !commander.sandbox;
 const noPrompt = !commander.prompt;
 const enableChromeNetworkService = commander.enableChromeNetworkService;
 const awsNoVerifySsl = !commander.verifySsl;
+const enableChromeSeamlessSso = commander.enableChromeSeamlessSso;
 
 Promise.resolve()
     .then(() => {
         if (commander.configure) return configureProfileAsync(profileName);
-        return login.loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl);
+        return login.loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso);
     })
     .catch(err => {
         if (err.name === "CLIError") {

--- a/lib/login.js
+++ b/lib/login.js
@@ -20,6 +20,9 @@ const HEIGHT = 550;
 const DELAY_ON_UNRECOGNIZED_PAGE = 1000;
 const MAX_UNRECOGNIZED_PAGE_DELAY = 30 * 1000;
 
+// source: https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-sso-quick-start#google-chrome-all-platforms
+const AZURE_AD_SSO = "autologon.microsoftazuread-sso.com";
+
 /**
  * To proxy the input/output of the Azure login page, it's easiest to run a loop that
  * monitors the state of the page and then perform the corresponding CLI behavior.
@@ -240,7 +243,7 @@ const states = [
 ];
 
 module.exports = {
-    async loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl) {
+    async loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso) {
         let headless, cliProxy;
         if (mode === 'cli') {
             headless = true;
@@ -257,7 +260,7 @@ module.exports = {
 
         const profile = await this._loadProfileAsync(profileName);
         const loginUrl = await this._createLoginUrlAsync(profile.azure_app_id_uri, profile.azure_tenant_id);
-        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, profile.azure_default_username, profile.azure_default_password);
+        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, profile.azure_default_username, profile.azure_default_password, enableChromeSeamlessSso);
         const roles = this._parseRolesFromSamlResponse(samlResponse);
         const { role, durationHours } = await this._askUserForRoleAndDurationAsync(roles, noPrompt, profile.azure_default_role_arn, profile.azure_default_duration_hours);
         await this._assumeRoleAsync(profileName, samlResponse, role, durationHours, awsNoVerifySsl);
@@ -358,13 +361,17 @@ module.exports = {
      * @returns {Promise.<string>} The SAML response.
      * @private
      */
-    async _performLoginAsync(url, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, defaultUsername, defaultPassword) {
+    async _performLoginAsync(url, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, defaultUsername, defaultPassword, enableChromeSeamlessSso) {
         debug("Loading login page in Chrome");
         let browser;
         try {
             const args = headless ? [] : [`--app=${url}`, `--window-size=${WIDTH},${HEIGHT}`];
             if (disableSandbox) args.push('--no-sandbox');
             if (enableChromeNetworkService) args.push('--enable-features=NetworkService');
+            if (enableChromeSeamlessSso) args.push(
+                `--auth-server-whitelist=${AZURE_AD_SSO}`,
+                `--auth-negotiate-delegate-whitelist=${AZURE_AD_SSO}`
+            );
 
             browser = await puppeteer.launch({
                 headless,


### PR DESCRIPTION
## Summary
This PR adds Chromium flags for pass-through authentication so that you are not asked for Azure AD ID and password when you are on the intranet or have a Kerberos ticket-granting ticket in your credentials cache/keytab file.

## How To Test
0. You need to have run `aws-azure-login --configure` before continuing. In addition, `azure_default_role_arn` and `azure_default_duration_hours` should preferably be set for seamless testing.
1. Run `kinit` command on your company's intranet providing your username or *sAMAccountName* (also known as samid or NTID) as an argument
2. Enter your password
3. Run `klist` to make sure you have been authenticated and have a valid Kerberos ticket, you should get an output similar to the following:
```
     Ticket cache: /tmp/krb5cc_ttypa
     Default principal: jennifer@ATHENA.MIT.EDU
     
     Valid starting     Expires            Service principal
     06/07/04 19:49:21  06/08/04 05:49:19  krbtgt/ATHENA.MIT.EDU@ATHENA.MIT.EDU
```
4. Run `aws-azure-login --no-prompt --enable-chrome-seamless-sso`
5. If everything goes smoothly, you should have AWS credentials in `~/.aws/credentials`

## Background
Kerberos is a network authentication protocol that supports Single Sign-On (SSO). For HTTP requests, support for Kerberos is provided by the SPNEGO authentication mechanism (Simple and Protected GSS-API Negotiation), also known as integration authentication or negotiate authentication. Chromium supports SPNEGO but it is disabled by default for security reasons.

To enable SPNEGO for Azure Active Directory Seamless Single Sign-On, Azure AD must be whitelisted using `--auth-server-whitelist` flag when Chromium is started. In addition, since Azure AD is a trusted domain, we need to use `--auth-negotiate-delegate-whitelist` flag to allow Kerberos delegation, so Chromium is allowed to negotiate with Azure AD on your behalf when you are already authenticated.