### PR TITLE
added aws_security_token for backwards compatibility with boto 2

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -598,6 +598,7 @@ module.exports = {
             aws_access_key_id: res.Credentials.AccessKeyId,
             aws_secret_access_key: res.Credentials.SecretAccessKey,
             aws_session_token: res.Credentials.SessionToken,
+            aws_security_token: res.Credentials.SessionToken,
             aws_session_expiration: res.Credentials.Expiration.toJSON()
         });
     }


### PR DESCRIPTION
I love this utility, but I noticed that it writes the session token to `aws_session_token`, but that `boto==2` uses `aws_security_token` for authenticating. Thus, when I tried to run a Python script, it was looking in the `credentials` file for the wrong token.

I decided to just duplicate them and write to both `aws_security_token` and `aws_session_token` and it seems to work fine with `boto==2`. I haven't tested on `boto3` yet, but it doesn't seem to impact the AWS CLI, so I think this is all that is needed for backwards compatibility with older versions of `boto`. 