### PR TITLE
Fix for issue #57 - Puppeteer error with --no-prompt

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -67,6 +67,8 @@ const states = [
             debug("Typing username");
             await page.keyboard.type(username);
 
+            await Bluebird.delay(500);
+
             debug("Submitting form");
             await page.click("input[type=submit]");
 


### PR DESCRIPTION
https://github.com/dtjohnson/aws-azure-login/issues/57

Introduce a slight delay between entering the username and submitting the form, this prevents the following error:

```
Logging in with profile 'xxxx'...
Error: Node is either not visible or not an HTMLElement
    at ElementHandle._clickablePoint (/aws-azure-login/node_modules/puppeteer/lib/ExecutionContext.js:331:13)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:229:7)
```