### PR TITLE
Add support for GovCloud.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Then install aws-azure-login:
 A Docker image has been built with aws-azure-login preinstalled. You simply need to run the command with a volume mounted to your AWS configuration directory.
 
     docker run --rm -it -v ~/.aws:/root/.aws sportradar/aws-azure-login
-    
+
 The Docker image is configured with an entrypoint so you can just feed any arguments in at the end.
 
 You can also put the docker-launch.sh script into your bin directory for the aws-azure-login command to function as usual:

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Install [Node.js](https://nodejs.org/) v7.6.0 or higher. Then install aws-azure-
 
 ### Linux
 
-In Linux you can either install for all users or just the current user. In either case, you must first install [Node.js](https://nodejs.org/) v7.6.0 or higher and any [puppeteer dependencies](https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch). Then follow the appropriate instructions. 
+In Linux you can either install for all users or just the current user. In either case, you must first install [Node.js](https://nodejs.org/) v7.6.0 or higher and any [puppeteer dependencies](https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch). Then follow the appropriate instructions.
 
 #### Option A: Install for All Users
 
 Install aws-azure-login globally with npm:
 
     sudo npm install -g aws-azure-login --unsafe-perm
-    
+
 Puppeteer doesn't install globally with execution permissions for all users so you'll need to modify them:
 
     sudo chmod -R go+rx $(npm root -g)
@@ -28,14 +28,14 @@ Puppeteer doesn't install globally with execution permissions for all users so y
 #### Option B: Install Only for Current User
 
 First configure npm to install global packages in [your home directory](https://docs.npmjs.com/getting-started/fixing-npm-permissions):
-   
+
     mkdir ~/.npm-global
     npm config set prefix '~/.npm-global'
     export PATH=~/.npm-global/bin:$PATH
     source ~/.profile
     echo 'export PATH=~/.npm-global/bin:$PATH' >> ~/.profile
     source ~/.profile
-     
+
 Then install aws-azure-login:
 
     npm install -g aws-azure-login
@@ -45,7 +45,7 @@ Then install aws-azure-login:
 A Docker image has been built with aws-azure-login preinstalled. You simply need to run the command with a volume mounted to your AWS configuration directory.
 
     docker run --rm -it -v ~/.aws:/root/.aws dtjohnson/aws-azure-login
-    
+
 The Docker image is configured with an entrypoint so you can just feed any arguments in at the end.
 
 You can also put the docker-launch.sh script into your bin directory for the aws-azure-login command to function as usual:
@@ -64,10 +64,17 @@ Now just run `aws-azure-login`.
 To configure the aws-azure-login client run:
 
     aws-azure-login --configure
-    
+
 You'll need your Azure Tenant ID and the App ID URI. To configure a named profile, use the --profile flag.
 
     aws-azure-login --configure --profile foo
+
+##### GovCloud Support
+
+To use aws-azure-login with AWS GovCloud, set the `region` profile property in your ~/.aws/config to the one of the GovCloud regions:
+
+* us-gov-west-1
+* us-gov-east-1
 
 #### Environment Variables
 
@@ -95,7 +102,7 @@ Use the `HISTCONTROL` environment variable to avoid storing the password in your
 Once aws-azure-login is configured, you can log in. For the default profile, just run:
 
     aws-azure-login
-    
+
 You will be prompted for your username and password. If MFA is required you'll also be prompted for a verification code or mobile device approval. To log in with a named profile:
 
     aws-azure-login --profile foo

--- a/lib/login.js
+++ b/lib/login.js
@@ -264,7 +264,7 @@ module.exports = {
 
         const profile = await this._loadProfileAsync(profileName);
         let assertionConsumerServiceURL = AWS_SAML_ENDPOINT;
-        if (profile.hasOwnProperty('region') && (profile.region.indexOf('us-gov-west') !== -1 || profile.region.indexOf('us-gov-east') !== -1)) {
+        if (profile.hasOwnProperty('region') && profile.region.startsWith('us-gov')) {
             assertionConsumerServiceURL = AWS_GOV_SAML_ENDPOINT;
         }
 
@@ -609,8 +609,8 @@ module.exports = {
 
         if (region) {
             AWS.config.update({
-                region: region
-            })
+                region
+            });
         }
 
         const sts = new AWS.STS();

--- a/lib/login.js
+++ b/lib/login.js
@@ -22,6 +22,8 @@ const MAX_UNRECOGNIZED_PAGE_DELAY = 30 * 1000;
 
 // source: https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-sso-quick-start#google-chrome-all-platforms
 const AZURE_AD_SSO = "autologon.microsoftazuread-sso.com";
+const AWS_SAML_ENDPOINT = "https://signin.aws.amazon.com/saml";
+const AWS_GOV_SAML_ENDPOINT = "https://signin.amazonaws-us-gov.com/saml";
 
 /**
  * To proxy the input/output of the Azure login page, it's easiest to run a loop that
@@ -259,11 +261,18 @@ module.exports = {
         }
 
         const profile = await this._loadProfileAsync(profileName);
-        const loginUrl = await this._createLoginUrlAsync(profile.azure_app_id_uri, profile.azure_tenant_id);
+        let assertionConsumerServiceURL = AWS_SAML_ENDPOINT;
+        if (profile.hasOwnProperty('region') && (profile.region.indexOf('us-gov-west') !== -1 || profile.region.indexOf('us-gov-east') !== -1)) {
+            assertionConsumerServiceURL = AWS_GOV_SAML_ENDPOINT;
+        }
+
+        console.log('Using AWS SAML endpoint', assertionConsumerServiceURL);
+
+        const loginUrl = await this._createLoginUrlAsync(profile.azure_app_id_uri, profile.azure_tenant_id, assertionConsumerServiceURL);
         const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, profile.azure_default_username, profile.azure_default_password, enableChromeSeamlessSso);
         const roles = this._parseRolesFromSamlResponse(samlResponse);
         const { role, durationHours } = await this._askUserForRoleAndDurationAsync(roles, noPrompt, profile.azure_default_role_arn, profile.azure_default_duration_hours);
-        await this._assumeRoleAsync(profileName, samlResponse, role, durationHours, awsNoVerifySsl);
+        await this._assumeRoleAsync(profileName, samlResponse, role, durationHours, awsNoVerifySsl, profile.region);
     },
 
     /**
@@ -322,14 +331,16 @@ module.exports = {
      * Create the Azure login SAML URL.
      * @param {string} appIdUri - The app ID URI
      * @param {string} tenantId - The Azure tenant ID
+     * @param {string} assertionConsumerServiceURL - The AWS SAML endpoint that Azure should send the SAML response to
      * @returns {string} The login URL
      * @private
      */
-    async _createLoginUrlAsync(appIdUri, tenantId) {
+    async _createLoginUrlAsync(appIdUri, tenantId, assertionConsumerServiceURL) {
         debug("Generating UUID for SAML request");
         const id = uuid.v4();
+
         const samlRequest = `
-        <samlp:AuthnRequest xmlns="urn:oasis:names:tc:SAML:2.0:metadata" ID="id${id}" Version="2.0" IssueInstant="${new Date().toISOString()}" IsPassive="false" AssertionConsumerServiceURL="https://signin.aws.amazon.com/saml" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+        <samlp:AuthnRequest xmlns="urn:oasis:names:tc:SAML:2.0:metadata" ID="id${id}" Version="2.0" IssueInstant="${new Date().toISOString()}" IsPassive="false" AssertionConsumerServiceURL="${assertionConsumerServiceURL}" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
             <Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion">${appIdUri}</Issuer>
             <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"></samlp:NameIDPolicy>
         </samlp:AuthnRequest>
@@ -391,7 +402,7 @@ module.exports = {
                 page.on('request', req => {
                     const url = req.url();
                     debug(`Request: ${url}`);
-                    if (url === 'https://signin.aws.amazon.com/saml') {
+                    if (url === AWS_SAML_ENDPOINT || url === AWS_GOV_SAML_ENDPOINT) {
                         resolve();
                         samlResponseData = req.postData();
                         req.respond({
@@ -575,10 +586,11 @@ module.exports = {
      * @param {string} role - The role to assume
      * @param {number} durationHours - The session duration in hours
      * @param {bool} awsNoVerifySsl - Whether to have the AWS CLI verify SSL
+     * @param {string} region - AWS region, if specified
      * @returns {Promise} A promise
      * @private
      */
-    async _assumeRoleAsync(profileName, assertion, role, durationHours, awsNoVerifySsl) {
+    async _assumeRoleAsync(profileName, assertion, role, durationHours, awsNoVerifySsl, region) {
         console.log(`Assuming role ${role.roleArn}`);
         if (process.env.https_proxy) {
             AWS.config.update({
@@ -592,6 +604,12 @@ module.exports = {
             AWS.config.update({
                 httpOptions: opt
             });
+        }
+
+        if (region) {
+            AWS.config.update({
+                region: region
+            })
         }
 
         const sts = new AWS.STS();


### PR DESCRIPTION
AWS GovCloud has a separate SAML endpoint from the other commercial regions, so this PR updates the code to use that endpoint if one of the GovCloud regions is specified in the `region` profile property.

Also needed to pass one of the GovCloud regions in when assuming a role, otherwise the Node SDK could not find the Azure IdP in AWS.