### PR TITLE
Fetch maximum duration for the chosen role

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -278,11 +278,13 @@ module.exports = {
         console.log('Using AWS SAML endpoint', assertionConsumerServiceURL);
 
         const loginUrl = await this._createLoginUrlAsync(profile.azure_app_id_uri, profile.azure_tenant_id, assertionConsumerServiceURL);
-        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, profile.azure_default_username, 
+        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, profile.azure_default_username,
             profile.azure_default_password, enableChromeSeamlessSso, profile.azure_default_remember_me, noDisableExtensions);
         const roles = this._parseRolesFromSamlResponse(samlResponse);
-        const { role, durationHours } = await this._askUserForRoleAndDurationAsync(roles, noPrompt, profile.azure_default_role_arn, profile.azure_default_duration_hours);
-        await this._assumeRoleAsync(profileName, samlResponse, role, durationHours, awsNoVerifySsl, profile.region);
+        const role = await this._askUserForRoleAsync(roles, noPrompt, profile.azure_default_role_arn);
+        const durationHours = await this._askUserForDurationAsync(role, noPrompt, profile.azure_default_duration_hours, profileName, samlResponse, awsNoVerifySsl, profile);
+        const durationMinutes = durationHours * 60;
+        await this._assumeRoleAsync(profileName, samlResponse, role, durationMinutes, awsNoVerifySsl, profile.region);
     },
 
     async loginAll(mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso, forceRefresh, noDisableExtensions) {
@@ -546,6 +548,7 @@ module.exports = {
         const saml = cheerio.load(samlText, { xmlMode: true });
 
         debug("Looking for role SAML attribute");
+
         const roles = saml("Attribute[Name='https://aws.amazon.com/SAML/Attributes/Role']>AttributeValue").map(function () {
             const roleAndPrincipal = saml(this).text();
             const parts = roleAndPrincipal.split(",");
@@ -565,13 +568,11 @@ module.exports = {
      * @param {Array.<{roleArn: string, principalArn: string}>} roles - The roles to pick from
      * @param {bool} [noPrompt] - Enable skipping of user prompting
      * @param {string} [defaultRoleArn] - The default role ARN
-     * @param {number} [defaultDurationHours] - The default session duration in hours
-     * @returns {Promise.<{role: string, durationHours: number}>} The selected role and duration
+     * @returns {Promise.<{}>} The selected role
      * @private
      */
-    async _askUserForRoleAndDurationAsync(roles, noPrompt, defaultRoleArn, defaultDurationHours) {
+    async _askUserForRoleAsync(roles, noPrompt, defaultRoleArn) {
         let role;
-        let durationHours;
         const questions = [];
         if (roles.length === 0) {
             throw new CLIError("No roles found in SAML response.");
@@ -597,19 +598,70 @@ module.exports = {
             }
         }
 
+        const answers = await inquirer.prompt(questions);
+        if (!role) role = _.find(roles, ["roleArn", answers.role]);
+        return role;
+    },
+
+    /**
+     * Determine the maximum duration allowed for a role
+     * @param {{roleArn: string, principalArn: string}} role - The role to fetch information for
+     * @param {{Credentials: {AccessKeyId: string, SecretAccessKey: string, sessionToken: string}}} creds - Credentials to use with IAM
+     * @returns {number} Maximum duration allowed
+     * @private
+     */
+    async _getMaximumDuration(role, creds) {
+        const iam = new AWS.IAM({
+            accessKeyId: creds.Credentials.AccessKeyId,
+            secretAccessKey: creds.Credentials.SecretAccessKey,
+            sessionToken: creds.Credentials.SessionToken
+        });
+        const roleList = await iam.listRoles().promise();
+        const roleDetails = _.find(roleList.Roles, ["Arn", role.roleArn]);
+        debug(roleDetails);
+        return roleDetails.MaxSessionDuration / 3600;
+    },
+
+    /**
+     * Ask the user how long to use the role for.
+     * @param {{roleArn: string, principalArn: string}} role - The role to assume
+     * @param {bool} [noPrompt] - Enable skipping of user prompting
+     * @param {number} [defaultDurationHours] - The default session duration in hours
+     * @param {string} profileName - The profile name
+     * @param {string} samlResponse - The SAML response
+     * @param {bool} awsNoVerifySsl - Whether to have the AWS CLI verify SSL
+     * @param {{}} profile - Profile
+     * @returns {Promise.<number>} The selected duration
+     * @private
+     */
+    async _askUserForDurationAsync(role, noPrompt, defaultDurationHours, profileName, samlResponse, awsNoVerifySsl, profile) {
+        let durationHours;
+        const questions = [];
         if (noPrompt && defaultDurationHours) {
             debug("Default durationHours found. No need to ask.");
             durationHours = defaultDurationHours;
         } else {
+            const minimumSessionDurationMinutes = 15;
+            const creds = await this._assumeRoleAsync(profileName, samlResponse, role, minimumSessionDurationMinutes, awsNoVerifySsl, profile.region);
+
+            let maxDurationHours;
+
+            try {
+                maxDurationHours = await this._getMaximumDuration(role, creds);
+            } catch (err) {
+                debug(err);
+                maxDurationHours = defaultDurationHours;
+            }
+
             questions.push({
                 name: "durationHours",
-                message: "Session Duration Hours (up to 12):",
+                message: `Session Duration Hours (up to ${maxDurationHours}):`,
                 type: "input",
-                default: defaultDurationHours || 1,
+                default: maxDurationHours || 1,
                 validate(input) {
                     input = Number(input);
-                    if (input > 0 && input <= 12) return true;
-                    return 'Duration hours must be between 0 and 12';
+                    if (input > 0 && input <= maxDurationHours) return true;
+                    return `Duration hours must be between 0 and ${maxDurationHours}`;
                 }
             });
         }
@@ -618,10 +670,9 @@ module.exports = {
         // user is logged in and using multiple profiles --all-profiles and --no-prompt
         if (questions.length > 0) {
             const answers = await inquirer.prompt(questions);
-            if (!role) role = _.find(roles, ["roleArn", answers.role]);
             if (!durationHours) durationHours = answers.durationHours;
         }
-        return { role, durationHours };
+        return durationHours;
     },
 
     /**
@@ -629,13 +680,13 @@ module.exports = {
      * @param {string} profileName - The profile name
      * @param {string} assertion - The SAML assertion
      * @param {string} role - The role to assume
-     * @param {number} durationHours - The session duration in hours
+     * @param {number} durationMinutes - The session duration in minutes
      * @param {bool} awsNoVerifySsl - Whether to have the AWS CLI verify SSL
      * @param {string} region - AWS region, if specified
      * @returns {Promise} A promise
      * @private
      */
-    async _assumeRoleAsync(profileName, assertion, role, durationHours, awsNoVerifySsl, region) {
+    async _assumeRoleAsync(profileName, assertion, role, durationMinutes, awsNoVerifySsl, region) {
         console.log(`Assuming role ${role.roleArn}`);
         if (process.env.https_proxy) {
             AWS.config.update({
@@ -662,7 +713,7 @@ module.exports = {
             PrincipalArn: role.principalArn,
             RoleArn: role.roleArn,
             SAMLAssertion: assertion,
-            DurationSeconds: Math.round(durationHours * 60 * 60)
+            DurationSeconds: Math.round(durationMinutes * 60)
         }).promise();
         await awsConfig.setProfileCredentialsAsync(profileName, {
             aws_access_key_id: res.Credentials.AccessKeyId,
@@ -670,5 +721,6 @@ module.exports = {
             aws_session_token: res.Credentials.SessionToken,
             aws_expiration: res.Credentials.Expiration.toISOString()
         });
+        return res;
     }
 };


### PR DESCRIPTION
The value for `MaxSessionDuration` depends on the role chosen by the
user. We can therefore not assume 12 hours to be the maximum.
In order to acquire the information necessary, we need to assume the
chosen role temporarily (using the minimum session length of 15
minutes) and contact IAM. We then ask the user for the desired session
length and present the user with the previously acquired maximum.

Fixes #93