### PR TITLE
Added "--refreshOnlyWhenExpired" for individual profile login

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -12,6 +12,7 @@ const login = require("../lib/login");
 
 commander
     .option("-p, --profile <name>", "The name of the profile to log in with (or configure)")
+    .option("-r, --refreshOnlyWhenExpired", "Skip credential refresh for given profile name, if they are still valid")
     .option("-a, --all-profiles", "Run for all configured profiles")
     .option("-f, --force-refresh", "Force a credential refresh, even if they are still valid")
     .option("-c, --configure", "Configure the profile")
@@ -32,6 +33,7 @@ const enableChromeNetworkService = commander.enableChromeNetworkService;
 const awsNoVerifySsl = !commander.verifySsl;
 const enableChromeSeamlessSso = commander.enableChromeSeamlessSso;
 const forceRefresh = commander.forceRefresh;
+const refreshOnlyWhenExpired = commander.refreshOnlyWhenExpired;
 const noDisableExtensions = !commander.disableExtensions;
 
 
@@ -42,7 +44,7 @@ Promise.resolve()
         }
 
         if (commander.configure) return configureProfileAsync(profileName);
-        return login.loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso, noDisableExtensions);
+        return login.loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso, refreshOnlyWhenExpired, noDisableExtensions);
     })
     .catch(err => {
         if (err.name === "CLIError") {

--- a/lib/login.js
+++ b/lib/login.js
@@ -254,8 +254,15 @@ const states = [
 ];
 
 module.exports = {
-    async loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso, noDisableExtensions) {
+    async loginAsync(profileName, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso, refreshOnlyWhenExpired, noDisableExtensions) {
         let headless, cliProxy;
+
+        debug(`Check if profile ${profileName} is expired or is about to expire`);
+        if (refreshOnlyWhenExpired && !await awsConfig.isProfileAboutToExpireAsync(profileName)) {
+            debug(`Profile ${profileName} not yet due for refresh.`);
+            return;
+        }
+
         if (mode === 'cli') {
             headless = true;
             cliProxy = true;
@@ -278,7 +285,7 @@ module.exports = {
         console.log('Using AWS SAML endpoint', assertionConsumerServiceURL);
 
         const loginUrl = await this._createLoginUrlAsync(profile.azure_app_id_uri, profile.azure_tenant_id, assertionConsumerServiceURL);
-        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, profile.azure_default_username, 
+        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, profile.azure_default_username,
             profile.azure_default_password, enableChromeSeamlessSso, profile.azure_default_remember_me, noDisableExtensions);
         const roles = this._parseRolesFromSamlResponse(samlResponse);
         const { role, durationHours } = await this._askUserForRoleAndDurationAsync(roles, noPrompt, profile.azure_default_role_arn, profile.azure_default_duration_hours);
@@ -287,16 +294,11 @@ module.exports = {
 
     async loginAll(mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso, forceRefresh, noDisableExtensions) {
         const profiles = await awsConfig.getAllProfileNames();
+        const refreshOnlyWhenExpired = !forceRefresh;
 
         for (const profile of profiles) {
-            debug(`Check if profile ${profile} is expired or is about to expire`);
-            if (!forceRefresh && !await awsConfig.isProfileAboutToExpireAsync(profile)) {
-                debug(`Profile ${profile} not yet due for refresh.`);
-                continue;
-            }
-
             debug(`Run login for profile: ${profile}`);
-            await this.loginAsync(profile, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso, noDisableExtensions);
+            await this.loginAsync(profile, mode, disableSandbox, noPrompt, enableChromeNetworkService, awsNoVerifySsl, enableChromeSeamlessSso, refreshOnlyWhenExpired, noDisableExtensions);
         }
     },
 


### PR DESCRIPTION
This allows you to run aws-azure-login multiple times (in automated way)
during day, without a need to input your credentials if your profile is
still valid.