### PR TITLE
Setting browser to false after closing it to prevent errors in the finally block

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -446,6 +446,7 @@ module.exports = {
                             body: ''
                         });
                         browser.close();
+                        browser = false;
                         debug(`Received SAML response, browser closed`);
                     } else {
                         req.continue();


### PR DESCRIPTION
Fixes: #103 

Soo, after trying to find a good way to check if the browser is still open (There is no function like that) I'm just setting the browser variable to false after closing it.
According to the puppeteer documentation, this should be fine, cause they state that the object is not useable anymore after close.

Other alternatives I considered:

Don't close the browser at that point. This leads to longer running processes and timeouts, cause there is a wait for navigation around line 459.

Rewrite the whole block, to take the different flows for
- stay logged in (Simple request to AWS and receiving the SAML response)
- for login needed (Redirect to azure, login flow, back to AWS)
better/more elegant into account.

Yeah, chosen the simplest one.