### PR TITLE
Make puppeteer respect proxy settings

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -278,7 +278,7 @@ module.exports = {
         console.log('Using AWS SAML endpoint', assertionConsumerServiceURL);
 
         const loginUrl = await this._createLoginUrlAsync(profile.azure_app_id_uri, profile.azure_tenant_id, assertionConsumerServiceURL);
-        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, profile.azure_default_username, 
+        const samlResponse = await this._performLoginAsync(loginUrl, headless, disableSandbox, cliProxy, noPrompt, enableChromeNetworkService, profile.azure_default_username,
             profile.azure_default_password, enableChromeSeamlessSso, profile.azure_default_remember_me, noDisableExtensions);
         const roles = this._parseRolesFromSamlResponse(samlResponse);
         const { role, durationHours } = await this._askUserForRoleAndDurationAsync(roles, noPrompt, profile.azure_default_role_arn, profile.azure_default_duration_hours);
@@ -327,6 +327,30 @@ module.exports = {
         debug('Environment');
         debug(safe_env);
         return env;
+    },
+
+    /**
+     * Gather proxy information from environment variables
+     * @returns {string} value of environment variable
+     * @private
+     */
+    _loadProxyFromEnv() {
+        var variables = [
+            'http_proxy',
+            'https_proxy',
+        ];
+        var proxy = null;
+        for (var i = 0; i < variables.length; i++) {
+            var opt = variables[i];
+            if (process.env[opt]) {
+                proxy = process.env[opt];
+                break;
+            } else if (process.env[opt.toUpperCase()]) {
+                proxy = process.env[opt.toUpperCase()];
+                break;
+            }
+        }
+        return proxy;
     },
 
     /**
@@ -418,6 +442,8 @@ module.exports = {
             }
             const ignoreDefaultArgs = noDisableExtensions ? ['--disable-extensions'] : [];
 
+            const proxy = this._loadProxyFromEnv();
+            if (proxy !== null) args.push(`--proxy-server=${proxy}`);
             browser = await puppeteer.launch({
                 headless,
                 args,


### PR DESCRIPTION
If http_proxy/https_proxy environment variable is found, then puppeteer should respect it.

I had to make this change to make it work through my corporate proxy.