### PR TITLE
add support for Azure + ADFS federation

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -228,7 +228,7 @@ const states = [
       await page.keyboard.type(password);
 
       // federation with on-prem ADFS causes an HTTP basic auth prompt inside a redirect here
-      await page.authenticate({'username': username, 'password': password});
+      await page.authenticate({'username': String(username), 'password': String(password)});
 
       debug("Submitting form");
       await page.click("span[class=submit],input[type=submit]");

--- a/src/login.ts
+++ b/src/login.ts
@@ -227,6 +227,9 @@ const states = [
       debug("Typing password");
       await page.keyboard.type(password);
 
+      // federation with on-prem ADFS causes an HTTP basic auth prompt inside a redirect here
+      await page.authenticate({'username': username, 'password': password});
+
       debug("Submitting form");
       await page.click("span[class=submit],input[type=submit]");
 

--- a/src/login.ts
+++ b/src/login.ts
@@ -228,7 +228,10 @@ const states = [
       await page.keyboard.type(password);
 
       // federation with on-prem ADFS causes an HTTP basic auth prompt inside a redirect here
-      await page.authenticate({'username': String(username), 'password': String(password)});
+      await page.authenticate({
+        username: String(username),
+        password: String(password),
+      });
 
       debug("Submitting form");
       await page.click("span[class=submit],input[type=submit]");

--- a/src/login.ts
+++ b/src/login.ts
@@ -33,6 +33,9 @@ interface Role {
   principalArn: string;
 }
 
+// eslint-disable-next-line no-var
+var username: string;
+
 /**
  * To proxy the input/output of the Azure login page, it's easiest to run a loop that
  * monitors the state of the page and then perform the corresponding CLI behavior.
@@ -61,8 +64,6 @@ const states = [
         );
         console.log(errorMessage);
       }
-
-      let username;
 
       if (noPrompt && defaultUsername) {
         debug("Not prompting user for username");


### PR DESCRIPTION
This fixes #143. I'm not a huge fan of adding a blind ".authenticate" by itself, but I'm not familiar enough with other implementations of Azure SSO to gauge what the impact might be.