### PR TITLE
Fix to allow Curl to follow links

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The Docker image is configured with an entrypoint so you can just feed any argum
 
 You can also put the docker-launch.sh script into your bin directory for the aws-azure-login command to function as usual:
 
-    sudo curl -o /usr/local/bin/aws-azure-login https://raw.githubusercontent.com/sportradar/aws-azure-login/main/docker-launch.sh
+    sudo curl -o /usr/local/bin/aws-azure-login https://raw.githubusercontent.com/sportradar/aws-azure-login/main/docker-launch.sh -L
     sudo chmod o+x /usr/local/bin/aws-azure-login
 
 Now just run `aws-azure-login`.


### PR DESCRIPTION
Was getting a 302 from the link, which caused shell script to be populated with HTML and not the actual script. Simple fix to make curl follow link.