### PR TITLE
Add proxy-server argument to puppeteer cli login if env variable is set

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -634,6 +634,11 @@ export const login = {
         await mkdirp(paths.chromium);
         args.push(`--user-data-dir=${paths.chromium}`);
       }
+
+      if (process.env.https_proxy) {
+        args.push(`--proxy-server=${process.env.https_proxy}`);
+      }
+
       const ignoreDefaultArgs = noDisableExtensions
         ? ["--disable-extensions"]
         : [];


### PR DESCRIPTION
Currently the package passes the https_proxy environment variable to the AWS sdk for assume role but not to puppeteer for the login making it impossible for headless logins for users that need proxy support.

