### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ You can also put the docker-launch.sh script into your bin directory for the aws
 
 Now just run `aws-azure-login`.
 
+If you find yourself operating behind a corporate proxy you may need to make use of the `--env , -e, --env-file` docker
+run options to ensure the correct proxy environment variables are set (i.e. `HTTP_PROXY` or `HTTPS_PROXY`). For more see
+[`setting-docker-envs`](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file).
+
 ### Snap
 
 https://snapcraft.io/aws-azure-login


### PR DESCRIPTION
Add a note to the docker installation section surrounding the usage of docker behind a corporate proxy. 

The vanilla docker run command did not work for me without the setting of the proxy environment variables. It took me quite some time to figure out why the container was simply 'hanging'. This addition to the README.md might help others, who are using the docker aws-azure-login option, troubleshoot faster.

I am happy for this addition to possibly be moved to the ['behind-corporate-proxy'](https://github.com/sportradar/aws-azure-login#behind-corporate-proxy) section. We could possibly then add a link in the docker section. However, for me personally, I find that I only really look at the markdown section that I am interested in (e.g. windows install vs. linux install). This is why I opted to add the note directly under the docker section, since the addition is very docker specific. 