### PR TITLE
Add flag to stop puppeteer from verifying SSL certificates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,10 @@ program
     "--no-disable-extensions",
     "Tell Puppeteer not to pass the --disable-extensions flag to Chromium"
   )
+  .option(
+    "--no-verify-ssl-puppeteer",
+    "Tell Puppeteer not verify SSL certificates"
+  )
   .parse(process.argv);
 
 const profileName =
@@ -63,6 +67,7 @@ const awsNoVerifySsl = !program.verifySsl;
 const enableChromeSeamlessSso = !!program.enableChromeSeamlessSso;
 const forceRefresh = !!program.forceRefresh;
 const noDisableExtensions = !program.disableExtensions;
+const puppeteerNoVerifySSL = !program.verifySslPuppeteer;
 
 Promise.resolve()
   .then(() => {
@@ -75,7 +80,8 @@ Promise.resolve()
         awsNoVerifySsl,
         enableChromeSeamlessSso,
         forceRefresh,
-        noDisableExtensions
+        noDisableExtensions,
+        puppeteerNoVerifySSL
       );
     }
 
@@ -88,7 +94,8 @@ Promise.resolve()
       enableChromeNetworkService,
       awsNoVerifySsl,
       enableChromeSeamlessSso,
-      noDisableExtensions
+      noDisableExtensions,
+      puppeteerNoVerifySSL
     );
   })
   .catch((err: Error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ program
   )
   .option(
     "--no-verify-ssl-puppeteer",
-    "Tell Puppeteer not verify SSL certificates"
+    "Tell Puppeteer not to verify SSL certificates"
   )
   .parse(process.argv);
 

--- a/src/login.ts
+++ b/src/login.ts
@@ -384,7 +384,8 @@ export const login = {
     enableChromeNetworkService: boolean,
     awsNoVerifySsl: boolean,
     enableChromeSeamlessSso: boolean,
-    noDisableExtensions: boolean
+    noDisableExtensions: boolean,
+    puppeteerNoVerifySSL: boolean
   ): Promise<void> {
     let headless, cliProxy;
     if (mode === "cli") {
@@ -427,7 +428,8 @@ export const login = {
       profile.azure_default_password,
       enableChromeSeamlessSso,
       profile.azure_default_remember_me,
-      noDisableExtensions
+      noDisableExtensions,
+      puppeteerNoVerifySSL
     );
     const roles = this._parseRolesFromSamlResponse(samlResponse);
     const { role, durationHours } = await this._askUserForRoleAndDurationAsync(
@@ -454,7 +456,8 @@ export const login = {
     awsNoVerifySsl: boolean,
     enableChromeSeamlessSso: boolean,
     forceRefresh: boolean,
-    noDisableExtensions: boolean
+    noDisableExtensions: boolean,
+    puppeteerNoVerifySSL: boolean
   ): Promise<void> {
     const profiles = await awsConfig.getAllProfileNames();
 
@@ -481,7 +484,8 @@ export const login = {
         enableChromeNetworkService,
         awsNoVerifySsl,
         enableChromeSeamlessSso,
-        noDisableExtensions
+        noDisableExtensions,
+        puppeteerNoVerifySSL
       );
     }
   },
@@ -598,6 +602,7 @@ export const login = {
    * @param {bool} [enableChromeSeamlessSso] - chrome seamless SSO
    * @param {bool} [rememberMe] - Enable remembering the session
    * @param {bool} [noDisableExtensions] - True to prevent Puppeteer from disabling Chromium extensions
+   * @param {bool} [puppeteerNoVerifySSL] - True to prevent Puppeteer from verifying SSL certificates
    * @returns {Promise.<string>} The SAML response.
    * @private
    */
@@ -612,7 +617,8 @@ export const login = {
     defaultPassword: string | undefined,
     enableChromeSeamlessSso: boolean,
     rememberMe: boolean,
-    noDisableExtensions: boolean
+    noDisableExtensions: boolean,
+    puppeteerNoVerifySSL: boolean
   ): Promise<string> {
     debug("Loading login page in Chrome");
 
@@ -643,7 +649,11 @@ export const login = {
         ? ["--disable-extensions"]
         : [];
 
+      if (puppeteerNoVerifySSL) {
+        args.push('--ignore-certificate-errors');
+      }
       browser = await puppeteer.launch({
+        ignoreHTTPSErrors: puppeteerNoVerifySSL ? true : false,
         headless,
         args,
         ignoreDefaultArgs,

--- a/src/login.ts
+++ b/src/login.ts
@@ -650,7 +650,7 @@ export const login = {
         : [];
 
       if (puppeteerNoVerifySSL) {
-        args.push('--ignore-certificate-errors');
+        args.push("--ignore-certificate-errors");
       }
       browser = await puppeteer.launch({
         ignoreHTTPSErrors: puppeteerNoVerifySSL ? true : false,


### PR DESCRIPTION
Hi, we currently use this tool internally with a HTTPS proxy which intercepts the SAML response.

As you can imagine the proxy has a self-signed cert which `aws-azure-login` doesn't like... adding these changes has fixed that for me. Would be great to see this merged since it has a use case with people within the company, am of course open to implement any suggestions in order for this to happen.