### PR TITLE
Add support to package a standalone executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ Now just run `aws-azure-login`.
 
 https://snapcraft.io/aws-azure-login
 
+### Packaging as a standalone executable
+
+A standalone executable can be built for Windows, macOS, and Linux using the `pkg` command:
+
+    npm install pkg -g
+    yarn
+    yarn build
+    pkg .
+
+This is useful for deploying the tool in environments with restricted Internet access.
+
 ## Usage
 
 ### Configuration

--- a/package.json
+++ b/package.json
@@ -59,5 +59,13 @@
     "prettier": "^2.2.1",
     "ts-node-dev": "^1.1.1",
     "typescript": "^4.1.3"
+  },
+  "pkg": {
+    "scripts": [
+        "./lib/*.js"
+     ],
+    "assets": [
+      "./node_modules/*"
+    ]
   }
 }


### PR DESCRIPTION
If it is useful for others, we used this approach to load aws-azure-login into an environment with limited Internet access, where we couldn't directly use yarn to download all of the dependencies.