### PR TITLE
adding additional warning to help troubleshoot problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,16 +78,24 @@ You'll need your [Azure Tenant ID and the App ID URI](#getting-your-tenant-id-an
 
 ##### GovCloud Support
 
-To use aws-azure-login with AWS GovCloud, set the `region` profile property in your ~/.aws/config to the one of the GovCloud regions:
+To use aws-azure-login with AWS GovCloud, set the `region` profile property to one of the following:
 
 - us-gov-west-1
 - us-gov-east-1
 
+using a command like the following
+
+    aws configure set region us-gov-west-1
+
 ##### China Region Support
 
-To use aws-azure-login with AWS China Cloud, set the `region` profile property in your ~/.aws/config to the China region:
+To use aws-azure-login with AWS China Cloud, set the `region` to the China region:
 
 - cn-north-1
+
+using a command like the following
+
+    aws configure set region cn-north-1
 
 #### Staying logged in, skip username/password for future logins
 

--- a/src/login.ts
+++ b/src/login.ts
@@ -402,13 +402,15 @@ export const login = {
 
     const profile = await this._loadProfileAsync(profileName);
     let assertionConsumerServiceURL = AWS_SAML_ENDPOINT;
+    if (!profile.region) {
+      console.log("WARN: Default region has not been set with AWS config.");
+    }
     if (profile.region && profile.region.startsWith("us-gov")) {
       assertionConsumerServiceURL = AWS_GOV_SAML_ENDPOINT;
     }
     if (profile.region && profile.region.startsWith("cn-")) {
       assertionConsumerServiceURL = AWS_CN_SAML_ENDPOINT;
     }
-
     console.log("Using AWS SAML endpoint", assertionConsumerServiceURL);
 
     const loginUrl = await this._createLoginUrlAsync(


### PR DESCRIPTION
Would love it if you would include this warning.  I deal with a lot of govcloud users and they always end up confused as to why this doesn't work, and it's usually because they haven't set a default region.  The script doesn't make it clear that it is using the default region from the config.  This would remedy that.