### PR TITLE
Added custom assertionConsumerServiceURL to handle wrong redirects

### DIFF
--- a/src/awsConfig.ts
+++ b/src/awsConfig.ts
@@ -19,6 +19,7 @@ export interface ProfileConfig {
   azure_default_password?: string;
   azure_default_role_arn: string;
   azure_default_duration_hours: string;
+  azure_assertion_consumer_service_url: string;
   region?: string;
   azure_default_remember_me: boolean;
   [key: string]: unknown;

--- a/src/configureProfileAsync.ts
+++ b/src/configureProfileAsync.ts
@@ -22,6 +22,12 @@ export async function configureProfileAsync(
       default: profile && profile.azure_app_id_uri,
     },
     {
+      name: "assertionConsumerServiceURL",
+      message: "Azure Assertion Consumer ID URI:",
+      validate: (input): boolean => !!input,
+      default: profile && profile.azure_assertion_consumer_service_url,
+    },
+    {
       name: "username",
       message: "Default Username:",
       default: profile && profile.azure_default_username,

--- a/src/login.ts
+++ b/src/login.ts
@@ -408,6 +408,9 @@ export const login = {
     if (profile.region && profile.region.startsWith("cn-")) {
       assertionConsumerServiceURL = AWS_CN_SAML_ENDPOINT;
     }
+    if (profile.azure_assertion_consumer_service_url) {
+      assertionConsumerServiceURL = profile.azure_assertion_consumer_service_url
+    }
 
     console.log("Using AWS SAML endpoint", assertionConsumerServiceURL);
 


### PR DESCRIPTION
Hello, 

I was configuring your CLI tool for my environment but i needed to have a custom assertionConsumerServiceURL inside my SAML request, so I added it and now the post SAML redirect is working correctly. I'd like to share it with you.