### PR TITLE
Add support for coca-cola federated login

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -78,7 +78,7 @@ const states = [
 
       debug("Waiting for a delay");
       await Bluebird.delay(500);
-    }
+    },
   },
   {
     name: "username input",

--- a/src/login.ts
+++ b/src/login.ts
@@ -42,6 +42,45 @@ interface Role {
  */
 const states = [
   {
+    name: "coca-cola login",
+    selector: `.signon-app`,
+    async handler(
+      page: puppeteer.Page,
+      _selected: puppeteer.ElementHandle,
+      noPrompt: boolean,
+      _defaultUsername: string,
+      defaultPassword: string
+    ): Promise<void> {
+      let password;
+
+      if (noPrompt && defaultPassword) {
+        debug("Not prompting user for password");
+        password = defaultPassword;
+      } else {
+        debug("Prompting user for password");
+        ({ password } = await inquirer.prompt([
+          {
+            name: "password",
+            message: "Password:",
+            type: "password",
+          } as Question,
+        ]));
+      }
+
+      debug("Focusing on coca-cola password input");
+      await page.focus("input#password");
+
+      debug("Typing password");
+      await page.keyboard.type(password);
+
+      debug("Submitting form");
+      await page.click("form.login-form [type=submit]");
+
+      debug("Waiting for a delay");
+      await Bluebird.delay(500);
+    }
+  },
+  {
     name: "username input",
     selector: `input[name="loginfmt"]:not(.moveOffScreen)`,
     async handler(


### PR DESCRIPTION
Hey, another PR.

I'm not sure if you're interested in this kind of PR (that's why i opened this one separated from the TOTP one), but this adds support for coca-cola's internal federated login page.

It's very self contained (just a new state), so shouldn't impact anyone who doesn't need it.