### PR TITLE
Allow running with empty profile, if tenant and app ids are set

### DIFF
--- a/src/awsConfig.ts
+++ b/src/awsConfig.ts
@@ -15,12 +15,12 @@ const refreshLimitInMs = 11 * 60 * 1000;
 export interface ProfileConfig {
   azure_tenant_id: string;
   azure_app_id_uri: string;
-  azure_default_username: string;
+  azure_default_username?: string;
   azure_default_password?: string;
-  azure_default_role_arn: string;
-  azure_default_duration_hours: string;
+  azure_default_role_arn?: string;
+  azure_default_duration_hours?: string;
   region?: string;
-  azure_default_remember_me: boolean;
+  azure_default_remember_me?: boolean;
   [key: string]: unknown;
 }
 

--- a/src/login.ts
+++ b/src/login.ts
@@ -518,7 +518,7 @@ export const login = {
 
   // Load the profile
   async _loadProfileAsync(profileName: string): Promise<ProfileConfig> {
-    var profile = await awsConfig.getProfileConfigAsync(profileName);
+    let profile = await awsConfig.getProfileConfigAsync(profileName);
 
     const env = this._loadProfileFromEnv();
 


### PR DESCRIPTION
Hey, sorry for opening so many PRs at once, but here's another small improvement.

Fixes #187
Fixes #154 

This allows the program to run with an empty profile, if (and only if) tenant and app ids are set in the environment. All other configurations use the environment values (if set) or use the same default values from `--config`.