### PR TITLE
Support for suspicious activity screen

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -42,6 +42,29 @@ interface Role {
  */
 const states = [
   {
+    name: "suspicious activity",
+    selectorX: `//div[text()="Suspicious activity detected"]`,
+    async handler(page: puppeteer.Page): Promise<void> {
+      debug("Waiting for verify button");
+      await page.waitForSelector(`input[value=Verify]:not(.moveOffScreen)`, {
+        visible: true,
+        timeout: 60000,
+      });
+
+      debug("Clicking verify button");
+      await page.click("input[value=Verify]:not(.moveOffScreen)");
+
+      debug("Waiting for otp button");
+      await page.waitForSelector(`[data-value=PhoneAppOTP]`, {
+        visible: true,
+        timeout: 60000,
+      });
+
+      debug("Clicking otp button");
+      await page.click("[data-value=PhoneAppOTP]");
+    },
+  },
+  {
     name: "username input",
     selector: `input[name="loginfmt"]:not(.moveOffScreen)`,
     async handler(
@@ -720,7 +743,11 @@ export const login = {
 
             let selected;
             try {
-              selected = await page.$(state.selector);
+              if (state.selectorX) {
+                [selected] = await page.$x(state.selectorX);
+              } else if (state.selector) {
+                selected = await page.$(state.selector);
+              }
             } catch (err) {
               if (err instanceof Error) {
                 // An error can be thrown if the page isn't in a good state.


### PR DESCRIPTION
This is the last one, i swear haha.

Well, trying to get the github action working i got into a new issue: it runs from a _very_ different IP than my home network. Of course Microsoft is whinny about it and forces you to enter MFA again (not sure why tho?).

Well, this PR adds supports to that "suspicious activity screen", clicking the button that redirects you to OTP auth (maybe it would be worth it to try and add support for SMS too? But i'm not sure what the classes are).

I haven't been able to find any (any at all) element exclusive to that screen, so i used a text to match the title ("Suspicious activity detected"). This is not the same as a normal selector, so i added an attribute (`selectorX`) for running [XPath](https://developer.mozilla.org/en-US/docs/Web/XPath) queries.