### PR TITLE
Use the gui mode on docker

### DIFF
--- a/docker-launch.sh
+++ b/docker-launch.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker run --rm -it -v ~/.aws:/root/.aws sportradar/aws-azure-login "$@"
+docker run --rm -it -v ~/.aws:/root/.aws -e DISPLAY="${DISPLAY}" -v /tmp/.X11-unix:/tmp/.X11-unix sportradar/aws-azure-login "$@"


### PR DESCRIPTION
Hi,
This is to be able to use the gui mode using the docker image: 

I'm sharing the DISPLAY variable and the /tmp/.X11-unix path to be able to launch a GUI application

Fixes #213 

Obviously, you need to allow remote connections to your X server, for example:

```
xhost +
```

kind regards,