### PR TITLE
feat: allow users to login to multiple profiles with regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ If you configure all profiles to stay logged in, you can easily skip the prompts
 This will allow you to automate the credentials refresh procedure, eg. by running a cronjob every 5 minutes.
 To skip unnecessary calls, the credentials are only getting refreshed if the time to expire is lower than 11 minutes.
 
+### Renew credentials for a subset of configured profiles
+
+You can renew credentials for a subset of profiles by combining `--all-profiles` and `--profile=<regex>`:
+
+    aws-azure-login --all-profiles --profile=^online-grocery- --no-prompt
+
+This would match any profiles that start with `online-grocery-`.
+
 ## Getting Your Tenant ID and App ID URI
 
 Your Azure AD system admin should be able to provide you with your Tenant ID and App ID URI. If you can't get it from them, you can scrape it from a login page from the myapps.microsoft.com page.

--- a/src/awsConfig.ts
+++ b/src/awsConfig.ts
@@ -112,13 +112,18 @@ export const awsConfig = {
     await this._saveAsync("credentials", credentials);
   },
 
-  async getAllProfileNames(): Promise<string[] | undefined> {
+  async getAllProfileNames(
+    profileMatcher: string
+  ): Promise<string[] | undefined> {
     debug(`Getting all configured profiles from config.`);
+    const re = new RegExp(profileMatcher);
     const config =
       (await this._loadAsync<{ [key: string]: ProfileConfig }>("config")) || {};
 
     const profiles = Object.keys(config).map(function (e) {
       return e.replace("profile ", "");
+    }).filter(function (e) {
+      return e.match(re);
     });
     debug(`Received profiles: ${profiles.toString()}`);
     return profiles;

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,10 @@ const noDisableExtensions = !options.disableExtensions;
 Promise.resolve()
   .then(() => {
     if (options.allProfiles) {
+      const profileMatcher = (options.profile as string | undefined) || ".*";
+
       return login.loginAll(
+        profileMatcher,
         mode,
         disableSandbox,
         noPrompt,

--- a/src/login.ts
+++ b/src/login.ts
@@ -447,6 +447,7 @@ export const login = {
   },
 
   async loginAll(
+    profileMatcher: string,
     mode: string,
     disableSandbox: boolean,
     noPrompt: boolean,
@@ -456,7 +457,7 @@ export const login = {
     forceRefresh: boolean,
     noDisableExtensions: boolean
   ): Promise<void> {
-    const profiles = await awsConfig.getAllProfileNames();
+    const profiles = await awsConfig.getAllProfileNames(profileMatcher);
 
     if (!profiles) {
       return;


### PR DESCRIPTION
Ths PR enables users to combine `--all-profiles` and `--profile` to match configured profiles based on a given regex pattern. This helps in cases where you have many many accounts configured but only want to login to a subset of those accounts.

Closes: #133 