### PR TITLE
Login selectors deprecated, updated to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-azure-login",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Use Azure AD SSO to log into the AWS CLI.",
   "main": "index.js",
   "author": {

--- a/src/login.ts
+++ b/src/login.ts
@@ -127,29 +127,18 @@ const states = [
   },
   {
     name: "account selection",
-    selector: `#aadTile > div > div.table-cell.tile-img > img`,
+    selector: `#tilesHolder > div.tile-container > div > div.table > div > div.table-cell.tile-img > img`,
     async handler(page: puppeteer.Page): Promise<void> {
       debug("Multiple accounts associated with username.");
-      const aadTile = await page.$("#aadTileTitle");
+      const Tile = await page.$("#tilesHolder > div.tile-container > div > div.table > div > div.table-cell.text-left.content > div");
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const aadTileMessage: string = await page.evaluate(
+      const TileMessage: string = await page.evaluate(
         // eslint-disable-next-line
         (a) => a.textContent,
-        aadTile
+        Tile
       );
 
-      const msaTile = await page.$("#msaTileTitle");
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const msaTileMessage: string = await page.evaluate(
-        // eslint-disable-next-line
-        (m) => m.textContent,
-        msaTile
-      );
-
-      const accounts = [
-        { message: aadTileMessage, selector: "#aadTileTitle" },
-        { message: msaTileMessage, selector: "#msaTileTitle" },
-      ];
+      const accounts = [{ message: TileMessage, selector: "#tilesHolder > div.tile-container > div > div.table > div > div.table-cell.text-left.content > div" }];
 
       let account;
       if (accounts.length === 0) {
@@ -167,7 +156,7 @@ const states = [
             message: "Account:",
             type: "list",
             choices: _.map(accounts, "message"),
-            default: aadTileMessage,
+            default: TileMessage,
           } as Question,
         ]);
 


### PR DESCRIPTION
This PR contains a fix for the login prompt. Microsoft have since updated their login page and their relevant selectors. This PR addresses that and allows use of the aws-azure-login cli without having to pass `--mode=gui prompt` 