### PR TITLE
Feat: slim docker image and secure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,22 @@
-FROM node:14-slim
+FROM node:14-alpine as build
+COPY . /aws-azure-login/
+RUN cd /aws-azure-login && yarn install && yarn build
 
-# Install Puppeteer dependencies: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch
-RUN apt-get update \
-   && apt-get install -y \
-   gconf-service \
-   libasound2 \
-   libatk1.0-0 \
-   libc6 \
-   libcairo2 \
-   libcups2 \
-   libdbus-1-3 \
-   libexpat1 \
-   libfontconfig1 \
-   libgcc1 \
-   libgconf-2-4 \
-   libgdk-pixbuf2.0-0 \
-   libglib2.0-0 \
-   libgtk-3-0 \
-   libnspr4 \
-   libpango-1.0-0 \
-   libpangocairo-1.0-0 \
-   libstdc++6 \
-   libx11-6 \
-   libx11-xcb1 \
-   libxcb1 \
-   libxcomposite1 \
-   libxcursor1 \
-   libxdamage1 \
-   libxext6 \
-   libxfixes3 \
-   libxi6 \
-   libxrandr2 \
-   libxrender1 \
-   libxss1 \
-   libxtst6 \
-   ca-certificates \
-   fonts-liberation \
-   libappindicator1 \
-   libnss3 \
-   lsb-release \
-   xdg-utils \
-   wget \
-   && apt-get -q -y clean \
-   && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
-
+FROM node:14-alpine as buildbin
+ENV PUPPETEER_EXECUTABLE_PATH="/usr/bin/chromium-browser" \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true" \
+    NODE_ENV=production
 COPY package.json yarn.lock /aws-azure-login/
+RUN cd /aws-azure-login && yarn install --production && \ 
+    npm prune --production
+COPY --from=build /aws-azure-login/lib /aws-azure-login/lib
+RUN npm install -g pkg --production && cd /aws-azure-login && pkg --compress GZip .
 
-RUN cd /aws-azure-login \
-   && yarn install --production
+FROM alpine:latest
+ENV PUPPETEER_EXECUTABLE_PATH="/usr/bin/chromium-browser" \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
+RUN apk update && apk upgrade --no-cache --available && \
+    apk add --no-cache udev ttf-freefont chromium
+COPY --from=buildbin /aws-azure-login/dist/aws-azure-login /aws-azure-login/aws-azure-login
 
-COPY lib /aws-azure-login/lib
-
-ENTRYPOINT ["node", "/aws-azure-login/lib", "--no-sandbox"]
+ENTRYPOINT ["/aws-azure-login/aws-azure-login", "--no-sandbox"]

--- a/package.json
+++ b/package.json
@@ -59,5 +59,10 @@
     "prettier": "^2.6.2",
     "ts-node-dev": "^1.1.1",
     "typescript": "^4.6.3"
+  },
+  "pkg": {
+    "assets": "node_modules/vm2/**/*",
+    "targets": [ "node14-alpine-x64" ],
+    "outputPath": "dist"
   }
 }


### PR DESCRIPTION
This PR allow this slim down Docker image from 1,19GB to 431MB. In same time, we secure the application by compile it in native code (using pkg), so we can use a final image without nodejs binaries embedded. In addition, we are avoiding the old built-in chromium of the PUPPETEER module and installing a newer version of the image distribution. The image is slightly faster and less consuming.