### PR TITLE
Dockerfile and instructions for users with Mac M1 Pro arm64 chipset

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,59 @@
+FROM --platform=linux/arm64/v8 node:16.17.0-slim
+
+# Install Puppeteer dependencies: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch
+RUN apt-get update \
+   && apt-get install -y \
+   gconf-service \
+   libasound2 \
+   libatk1.0-0 \
+   libc6 \
+   libcairo2 \
+   libcups2 \
+   libdbus-1-3 \
+   libexpat1 \
+   libfontconfig1 \
+   libgcc1 \
+   libgconf-2-4 \
+   libgdk-pixbuf2.0-0 \
+   libglib2.0-0 \
+   libgtk-3-0 \
+   libnspr4 \
+   libpango-1.0-0 \
+   libpangocairo-1.0-0 \
+   libstdc++6 \
+   libx11-6 \
+   libx11-xcb1 \
+   libxcb1 \
+   libxcomposite1 \
+   libxcursor1 \
+   libxdamage1 \
+   libxext6 \
+   libxfixes3 \
+   libxi6 \
+   libxrandr2 \
+   libxrender1 \
+   libxss1 \
+   libxtst6 \
+   ca-certificates \
+   fonts-liberation \
+   libappindicator1 \
+   libnss3 \
+   lsb-release \
+   xdg-utils \
+   wget \
+   chromium \
+   && apt-get -q -y clean \
+   && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
+
+ARG CHROM=/usr/bin/chromium
+ENV PUPPETEER_EXECUTABLE_PATH=$CHROM
+
+COPY package.json yarn.lock /aws-azure-login/
+
+RUN cd /aws-azure-login \
+   && yarn install --production
+
+COPY lib /aws-azure-login/lib
+
+ENTRYPOINT ["node", "/aws-azure-login/lib", "--no-sandbox"]
+

--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ Now just run `aws-azure-login`.
 
 https://snapcraft.io/aws-azure-login
 
+### Mac with M1 Pro chipset (arm64)
+Both of the bellow methods have been tested to work on Mac with M1 Pro CPU.
+
+#### Local installation on Mac (for all users)
+Install `node`, `npm`, `pupeteer` and `chromium`.
+
+Set environment variables for `pupeteer` then install `aws-azure-login`
+
+    export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+    export PUPPETEER_EXECUTABLE_PATH=`which chromium`
+    sudo npm install -g aws-azure-login --unsafe-perm
+    sudo chmod -R go+rx $(npm root -g)
+
+
+#### Docker container on Mac
+Use the Dockerfile.arm64 to build your container example:
+    docker build -t aws-azure-login-arm64 -f Dockerfile.arm64 .
+
 ## Usage
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -71,11 +71,13 @@ https://snapcraft.io/aws-azure-login
 Both of the bellow methods have been tested to work on Mac with M1 Pro CPU.
 
 #### Local installation on Mac (for all users)
-Install `node`, `npm`, `pupeteer` and `chromium`.
+First install `node`, `npm` and `chromium` on your Mac.
 
-Set environment variables for `pupeteer` then install `aws-azure-login`:
+Set environment variables for `pupeteer`, then install it localy.
+Finally install `aws-azure-login`:
 
     export PUPPETEER_EXECUTABLE_PATH=`which chromium`
+    npm install puppeteer
     sudo npm install -g aws-azure-login --unsafe-perm
     sudo chmod -R go+rx $(npm root -g)
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Set environment variables for `pupeteer` then install `aws-azure-login`
 
 
 #### Docker container on Mac
-Use the Dockerfile.arm64 to build your container example:
+Use the `Dockerfile.arm64` to build your container example:
+
     docker build -t aws-azure-login-arm64 -f Dockerfile.arm64 .
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Finally install `aws-azure-login`:
 
 #### Docker container on Mac
 Fisrt build the app according to the steps from `.github/workflows/main.yml`:
+
     yarn install
     yarn test
     yarn build

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Finally install `aws-azure-login`:
 
 
 #### Docker container on Mac
+Fisrt build the app according to the steps from `.github/workflows/main.yml`:
+    yarn install
+    yarn test
+    yarn build
+
 Use the `Dockerfile.arm64` to build your container example:
 
     docker build -t aws-azure-login-arm64 -f Dockerfile.arm64 .

--- a/README.md
+++ b/README.md
@@ -73,9 +73,8 @@ Both of the bellow methods have been tested to work on Mac with M1 Pro CPU.
 #### Local installation on Mac (for all users)
 Install `node`, `npm`, `pupeteer` and `chromium`.
 
-Set environment variables for `pupeteer` then install `aws-azure-login`
+Set environment variables for `pupeteer` then install `aws-azure-login`:
 
-    export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
     export PUPPETEER_EXECUTABLE_PATH=`which chromium`
     sudo npm install -g aws-azure-login --unsafe-perm
     sudo chmod -R go+rx $(npm root -g)


### PR DESCRIPTION
Includes a dockerfile for building an arm64 container + update to node16
Updated README.md with instructions
Tested to be working on Apple Mac with M1 Pro chipset