### PR TITLE
fix: display authentication code

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -251,6 +251,14 @@ const states = [
       );
       console.log(descriptionMessage);
 
+      if (descriptionMessage.includes("enter the number shown to sign in")) {
+        const authenticationCodeElement = await page.$("#idRichContext_DisplaySign");
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const authenticationCode = await page.evaluate(
+        // eslint-disable-next-line
+        (d) => d.textContent, authenticationCodeElement);
+        console.log(authenticationCode);
+      }
       debug("Waiting for response");
       await page.waitForSelector(`#idDiv_SAOTCAS_Description`, {
         hidden: true,

--- a/src/login.ts
+++ b/src/login.ts
@@ -250,7 +250,7 @@ const states = [
         selected
       );
       console.log(descriptionMessage);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      // eslint-disable-next-line
       if (descriptionMessage.includes("enter the number shown to sign in")) {
         const authenticationCodeElement = await page.$("#idRichContext_DisplaySign");
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/src/login.ts
+++ b/src/login.ts
@@ -252,11 +252,15 @@ const states = [
       console.log(descriptionMessage);
       // eslint-disable-next-line
       if (descriptionMessage.includes("enter the number shown to sign in")) {
-        const authenticationCodeElement = await page.$("#idRichContext_DisplaySign");
+        const authenticationCodeElement = await page.$(
+          "#idRichContext_DisplaySign"
+        );
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const authenticationCode = await page.evaluate(
-        // eslint-disable-next-line
-        (d) => d.textContent, authenticationCodeElement);
+          // eslint-disable-next-line
+          (d) => d.textContent,
+          authenticationCodeElement
+        );
         console.log(authenticationCode);
       }
       debug("Waiting for response");

--- a/src/login.ts
+++ b/src/login.ts
@@ -250,7 +250,7 @@ const states = [
         selected
       );
       console.log(descriptionMessage);
-
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (descriptionMessage.includes("enter the number shown to sign in")) {
         const authenticationCodeElement = await page.$("#idRichContext_DisplaySign");
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment


### PR DESCRIPTION
resolves #248 

Prints the authentication code displayed in the page so that the user can enter it into the device