### PR TITLE
Ensure all languages work with auth codes

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -291,20 +291,22 @@ const states = [
         (description) => description.textContent,
         selected
       );
+
+      const authenticationCodeElement = await page.$(
+        "#idRichContext_DisplaySign"
+      );
+      debug("Reading the authentication code");
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const authenticationCode = await page.evaluate(
+        // eslint-disable-next-line
+        (d) => d.textContent,
+        authenticationCodeElement
+      );
+
       console.log(descriptionMessage);
       debug("Checking if authentication code is displayed");
       // eslint-disable-next-line
-      if (descriptionMessage.includes("enter the number shown to sign in")) {
-        const authenticationCodeElement = await page.$(
-          "#idRichContext_DisplaySign"
-        );
-        debug("Reading the authentication code");
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const authenticationCode = await page.evaluate(
-          // eslint-disable-next-line
-          (d) => d.textContent,
-          authenticationCodeElement
-        );
+      if (descriptionMessage.length && authenticationCode.length) {
         debug("Printing the authentication code to console");
         console.log(authenticationCode);
       }


### PR DESCRIPTION
Very naive fix for the issue with Azure returning other languages' login pages when being prompted to enter an auth code into Azure Authenticator.  Definitely open to feedback if there is another approach can be taken here.

Fixes #263 