### PR TITLE
Always request English version of pages

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -727,7 +727,7 @@ export const login = {
       const pages = await browser.pages();
       const page = pages[0];
       await page.setExtraHTTPHeaders({
-        "Accept-Language": "en",
+        "Accept-Language": "en"
       });
       await page.setViewport({ width: WIDTH - 15, height: HEIGHT - 35 });
 

--- a/src/login.ts
+++ b/src/login.ts
@@ -727,7 +727,7 @@ export const login = {
       const pages = await browser.pages();
       const page = pages[0];
       await page.setExtraHTTPHeaders({
-        "Accept-Language": "en"
+        "Accept-Language": "en",
       });
       await page.setViewport({ width: WIDTH - 15, height: HEIGHT - 35 });
 

--- a/src/login.ts
+++ b/src/login.ts
@@ -725,7 +725,7 @@ export const login = {
       await Bluebird.delay(200);
 
       const pages = await browser.pages();
-      const page = pages[0];
+      let page = pages[0];
       page.setExtraHTTPHeaders({
         "Accept-Language": "en"
       });

--- a/src/login.ts
+++ b/src/login.ts
@@ -726,6 +726,9 @@ export const login = {
 
       const pages = await browser.pages();
       const page = pages[0];
+      page.setExtraHTTPHeaders({
+        "Accept-Language": "en"
+      });
       await page.setViewport({ width: WIDTH - 15, height: HEIGHT - 35 });
 
       // Prevent redirection to AWS

--- a/src/login.ts
+++ b/src/login.ts
@@ -725,8 +725,8 @@ export const login = {
       await Bluebird.delay(200);
 
       const pages = await browser.pages();
-      let page = pages[0];
-      page.setExtraHTTPHeaders({
+      const page = pages[0];
+      await page.setExtraHTTPHeaders({
         "Accept-Language": "en"
       });
       await page.setViewport({ width: WIDTH - 15, height: HEIGHT - 35 });


### PR DESCRIPTION
Changing the Azure language or the Windows OS language doesn't fix the fix in #263. The headless Chromium still requests a language which is not English in my case. Therefore the identification for the number in the "number matching" 2FA mechanism doesn't work.

Requesting the English version of the login page explicitly allows to identify and extract the digits for the "number matching" mechanism. Works for me with a seemingly German Azure account.

Fixes #263