### PR TITLE
Allow config of Azure AD authentication endpoints

### DIFF
--- a/src/awsConfig.ts
+++ b/src/awsConfig.ts
@@ -15,6 +15,7 @@ const refreshLimitInMs = 11 * 60 * 1000;
 export interface ProfileConfig {
   azure_tenant_id: string;
   azure_app_id_uri: string;
+  azure_authentication_endpoint: string;
   azure_default_username: string;
   azure_default_password?: string;
   azure_default_role_arn: string;

--- a/src/azureEndpoints.ts
+++ b/src/azureEndpoints.ts
@@ -1,0 +1,8 @@
+// source: https://learn.microsoft.com/en-us/azure/active-directory/develop/authentication-national-cloud#azure-ad-authentication-endpoints
+export const AZURE_AD_AUTHENTICATION_ENDPOINTS = [
+  'login.microsoftonline.us',
+  'login.partner.microsoftonline.cn',
+  'login.microsoftonline.com'
+];
+
+export const AZURE_AD_DEFAULT_AUTHENTICATION_ENDPOINT = 'login.microsoftonline.com';

--- a/src/configureProfileAsync.ts
+++ b/src/configureProfileAsync.ts
@@ -1,5 +1,6 @@
 import inquirer, { Question } from "inquirer";
 import { awsConfig } from "./awsConfig";
+import { AZURE_AD_AUTHENTICATION_ENDPOINTS, AZURE_AD_DEFAULT_AUTHENTICATION_ENDPOINT } from "./azureEndpoints";
 
 export async function configureProfileAsync(
   profileName: string
@@ -20,6 +21,17 @@ export async function configureProfileAsync(
       message: "Azure App ID URI:",
       validate: (input): boolean => !!input,
       default: profile && profile.azure_app_id_uri,
+    },
+    {
+      name: "azureAuthenticationEndpoint",
+      message: "Azure AD authentication endpoint:",
+      default: (profile && profile.azure_authentication_endpoint) || AZURE_AD_DEFAULT_AUTHENTICATION_ENDPOINT,
+      validate: (input): boolean | string => {
+        if (input && !AZURE_AD_AUTHENTICATION_ENDPOINTS.includes(input as string)) {
+          return `Invalid Azure AD authentication endpoint. Must be one of: ${AZURE_AD_AUTHENTICATION_ENDPOINTS.join(', ')}`;
+        }
+        return true;
+      }
     },
     {
       name: "username",
@@ -62,6 +74,7 @@ export async function configureProfileAsync(
   await awsConfig.setProfileConfigValuesAsync(profileName, {
     azure_tenant_id: answers.tenantId as string,
     azure_app_id_uri: answers.appIdUri as string,
+    azure_authentication_endpoint: answers.azureAuthenticationEndpoint as string,
     azure_default_username: answers.username as string,
     azure_default_role_arn: answers.defaultRoleArn as string,
     azure_default_duration_hours: answers.defaultDurationHours as string,


### PR DESCRIPTION
This change allows for variation of the Azure AD authentication endpoint used during the SAML exchange. This is useful in the case that the Azure AD tenant and application are within a national cloud and not the global / commercial space.

Reference: https://learn.microsoft.com/en-us/azure/active-directory/develop/authentication-national-cloud#azure-ad-authentication-endpoints

_**NOTE:** I made these changes with an eye towards backwards compatibility._