### PR TITLE
Allow store of Chromium data per Azure AD tenant

### DIFF
--- a/src/awsConfig.ts
+++ b/src/awsConfig.ts
@@ -21,6 +21,7 @@ export interface ProfileConfig {
   azure_default_duration_hours: string;
   region?: string;
   azure_default_remember_me: boolean;
+  chrome_data_by_azure_tenant: boolean;
   [key: string]: unknown;
 }
 

--- a/src/configureProfileAsync.ts
+++ b/src/configureProfileAsync.ts
@@ -55,6 +55,19 @@ export async function configureProfileAsync(
         return "Duration hours must be between 0 and 12";
       },
     },
+    {
+      name: "chromeDataByAzureTenant",
+      message: "Store Chrome user data by Azure AD tenant",
+      default:
+        (profile &&
+          profile.chrome_data_by_azure_tenant &&
+          profile.chrome_data_by_azure_tenant.toString()) ||
+        "false",
+      validate: (input): boolean | string => {
+        if (input === "true" || input === "false") return true;
+        return "Chrome user data by Azure tenant must be either true or false";
+      },
+    },
   ];
 
   const answers = await inquirer.prompt(questions);
@@ -66,6 +79,7 @@ export async function configureProfileAsync(
     azure_default_role_arn: answers.defaultRoleArn as string,
     azure_default_duration_hours: answers.defaultDurationHours as string,
     azure_default_remember_me: (answers.rememberMe as string) === "true",
+    chrome_data_by_azure_tenant: (answers.chromeDataByAzureTenant as string) === "true",
   });
 
   console.log("Profile saved.");


### PR DESCRIPTION
This change allows for storing of the Chromium user data on a per Azure AD tenant basis for opted-in AWS config named profiles. The point here is that some users interact with more than one Azure AD tenant and want to leverage the remember me functionality in an unsurprising way. With the Chromium user data stored in one fixed location, authentication attempts that cross back and forth between Azure AD tenants aren't guaranteed to work. This feature ensures a strict separation between the stored user data on a per tenant basis and ensures remembered login items are never blindly used in an incorrect fashion.

Given an AWS config with a named profiles like:

```ini
[profile a]
...
azure_tenant_id=tenant-a
chrome_data_by_azure_tenant=true
...

[profile b]
...
azure_tenant_id=tenant-a
chrome_data_by_azure_tenant=true

[profile c]
...
azure_tenant_id=tenant-b
chrome_data_by_azure_tenant=true
...

[profile d]
...
azure_tenant_id=tenant-b
chrome_data_by_azure_tenant=true
...
```

The Chrome user data will be stored separately under `tenant-a` for profiles `a` and `b` from that of `tenant-b` for profiles `c` and `d`. Existing profiles out in the wild as well as any profiles for which `chrome_data_by_azure_tenant` is either missing or set to `false` will fall back to the historical behavior of all Chrome user data being slotted under a static directory.