### PR TITLE
AWS SDK for JavaScript V3

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -3,6 +3,7 @@ import Bluebird from "bluebird";
 import inquirer, { QuestionCollection, Question } from "inquirer";
 import zlib from "zlib";
 import AWS from "aws-sdk";
+import { STS } from "@aws-sdk/client-sts";
 import cheerio from "cheerio";
 import { v4 } from "uuid";
 import puppeteer, { HTTPRequest } from "puppeteer";
@@ -1034,15 +1035,14 @@ export const login = {
       });
     }
 
-    const sts = new AWS.STS();
+    const sts = new STS();
     const res = await sts
       .assumeRoleWithSAML({
         PrincipalArn: role.principalArn,
         RoleArn: role.roleArn,
         SAMLAssertion: assertion,
         DurationSeconds: Math.round(durationHours * 60 * 60),
-      })
-      .promise();
+      });
 
     if (!res.Credentials) {
       debug("Unable to get security credentials from AWS");


### PR DESCRIPTION
Followed the [instructions](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/migrating-to-v3.html) from Amazon after receiving the following note on version 3.6.1:
![image](https://user-images.githubusercontent.com/2853757/232808429-22e84251-bb47-4b9c-96bf-3fec1f07b2f8.png)

Seems like only 1 file needed to be updated.

After installing with: `npm install -g aws-azure-login`

I run the same command and didn't get the note.