### PR TITLE
Adds support for credential process used by aws cli

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,10 @@ program
     "--disable-gpu",
     "Tell Puppeteer to pass the --disable-gpu flag to Chromium"
   )
+  .option(
+    "--credential-process",
+    "Enable JSON output in the appropriate format to be usable as a Credential Process"
+  )
   .parse(process.argv);
 
 const options = program.opts();
@@ -70,6 +74,7 @@ const enableChromeSeamlessSso = !!options.enableChromeSeamlessSso;
 const forceRefresh = !!options.forceRefresh;
 const noDisableExtensions = !options.disableExtensions;
 const disableGpu = !!options.disableGpu;
+const credentialProcess = !!options.credentialProcess;
 
 Promise.resolve()
   .then(() => {
@@ -83,7 +88,8 @@ Promise.resolve()
         enableChromeSeamlessSso,
         forceRefresh,
         noDisableExtensions,
-        disableGpu
+        disableGpu,
+        credentialProcess
       );
     }
 
@@ -97,7 +103,8 @@ Promise.resolve()
       awsNoVerifySsl,
       enableChromeSeamlessSso,
       noDisableExtensions,
-      disableGpu
+      disableGpu,
+      credentialProcess
     );
   })
   .catch((err: Error) => {


### PR DESCRIPTION
Note: Although I'm a seasoned developer, this is my first foray into the JS ecosystem, so please feel free to give me constructive criticism on the changes submitted here, and I'll get in line with any styles or patterns I should adopt that I have not.

This change adds a new flag `--credential-process` which modifies the script to return a JSON formatted string consistent with what is needed to use it as an external credential process in conjunction with the AWS cli: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html

With this change, the `~/.aws/config` file can be modified to something along the lines of: `credential_process=aws-azure-login --no-prompt --credential-process` thereby using this tool to authenticate entirely transparently.