### PR TITLE
Add option to Configure Chromium Executable to be used by Puppeteer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,11 @@ program
     false
   )
   .option(
+    "--chromium-executable-path <chromiumExecutablePath>",
+    "Path to the Chromium executable to be used by Puppeteer",
+    undefined
+  )
+  .option(
     "--enable-chrome-network-service",
     "Enable Chromium's Network Service (needed when login provider redirects with 3XX)"
   )
@@ -64,6 +69,8 @@ const profileName =
 const mode = (options.mode as string | undefined) || "cli";
 const disableSandbox = !options.sandbox;
 const noPrompt = !options.prompt;
+const chromiumExecutablePath =
+  (options.chromiumExecutablePath as string | undefined) || undefined;
 const enableChromeNetworkService = !!options.enableChromeNetworkService;
 const awsNoVerifySsl = !options.verifySsl;
 const enableChromeSeamlessSso = !!options.enableChromeSeamlessSso;
@@ -83,7 +90,8 @@ Promise.resolve()
         enableChromeSeamlessSso,
         forceRefresh,
         noDisableExtensions,
-        disableGpu
+        disableGpu,
+        chromiumExecutablePath
       );
     }
 
@@ -97,7 +105,8 @@ Promise.resolve()
       awsNoVerifySsl,
       enableChromeSeamlessSso,
       noDisableExtensions,
-      disableGpu
+      disableGpu,
+      chromiumExecutablePath
     );
   })
   .catch((err: Error) => {

--- a/src/login.ts
+++ b/src/login.ts
@@ -448,7 +448,8 @@ export const login = {
     awsNoVerifySsl: boolean,
     enableChromeSeamlessSso: boolean,
     noDisableExtensions: boolean,
-    disableGpu: boolean
+    disableGpu: boolean,
+    chromiumExecutablePath: string | undefined
   ): Promise<void> {
     let headless, cliProxy;
     if (mode === "cli") {
@@ -492,7 +493,8 @@ export const login = {
       enableChromeSeamlessSso,
       profile.azure_default_remember_me,
       noDisableExtensions,
-      disableGpu
+      disableGpu,
+      chromiumExecutablePath
     );
     const roles = this._parseRolesFromSamlResponse(samlResponse);
     const { role, durationHours } = await this._askUserForRoleAndDurationAsync(
@@ -520,7 +522,8 @@ export const login = {
     enableChromeSeamlessSso: boolean,
     forceRefresh: boolean,
     noDisableExtensions: boolean,
-    disableGpu: boolean
+    disableGpu: boolean,
+    chromiumExecutablePath: string | undefined
   ): Promise<void> {
     const profiles = await awsConfig.getAllProfileNames();
 
@@ -548,7 +551,8 @@ export const login = {
         awsNoVerifySsl,
         enableChromeSeamlessSso,
         noDisableExtensions,
-        disableGpu
+        disableGpu,
+        chromiumExecutablePath
       );
     }
   },
@@ -666,6 +670,7 @@ export const login = {
    * @param {bool} [rememberMe] - Enable remembering the session
    * @param {bool} [noDisableExtensions] - True to prevent Puppeteer from disabling Chromium extensions
    * @param {bool} [disableGpu] - Disables GPU Acceleration
+   * @param {string} chromiumExecutablePath - Optional path to the Chromium executable to be used by Puppeteer
    * @returns {Promise.<string>} The SAML response.
    * @private
    */
@@ -681,7 +686,8 @@ export const login = {
     enableChromeSeamlessSso: boolean,
     rememberMe: boolean,
     noDisableExtensions: boolean,
-    disableGpu: boolean
+    disableGpu: boolean,
+    chromiumExecutablePath: string | undefined
   ): Promise<string> {
     debug("Loading login page in Chrome");
 
@@ -720,6 +726,7 @@ export const login = {
         headless,
         args,
         ignoreDefaultArgs,
+        executablePath: chromiumExecutablePath || undefined,
       });
 
       // Wait for a bit as sometimes the browser isn't ready.


### PR DESCRIPTION
Some companies prohibit the execution of Chromium. (Surprise, my company is one of them). This introduces an additional command line argument to specify a custom Chrome/Chromium executable.