### PR TITLE
Update Puppeteer dependencies in Docker image and publish to aws-azure-login repo instead of sportradar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Publish to Registry
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
-          name: sportradar/aws-azure-login
+          name: aws-azure-login/aws-azure-login
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           snapshot: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@ FROM node:14-slim
 # Install Puppeteer dependencies: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch
 RUN apt-get update \
    && apt-get install -y \
-   gconf-service \
+   ca-certificates \
+   fonts-liberation \
    libasound2 \
+   libatk-bridge2.0-0 \
    libatk1.0-0 \
    libc6 \
    libcairo2 \
@@ -12,12 +14,12 @@ RUN apt-get update \
    libdbus-1-3 \
    libexpat1 \
    libfontconfig1 \
+   libgbm1 \
    libgcc1 \
-   libgconf-2-4 \
-   libgdk-pixbuf2.0-0 \
    libglib2.0-0 \
    libgtk-3-0 \
    libnspr4 \
+   libnss3 \
    libpango-1.0-0 \
    libpangocairo-1.0-0 \
    libstdc++6 \
@@ -34,13 +36,9 @@ RUN apt-get update \
    libxrender1 \
    libxss1 \
    libxtst6 \
-   ca-certificates \
-   fonts-liberation \
-   libappindicator1 \
-   libnss3 \
    lsb-release \
-   xdg-utils \
    wget \
+   xdg-utils \
    && apt-get -q -y clean \
    && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ Then install aws-azure-login:
 
 A Docker image has been built with aws-azure-login preinstalled. You simply need to run the command with a volume mounted to your AWS configuration directory.
 
-    docker run --rm -it -v ~/.aws:/root/.aws sportradar/aws-azure-login
+    docker run --rm -it -v ~/.aws:/root/.aws aws-azure-login/aws-azure-login
 
 The Docker image is configured with an entrypoint so you can just feed any arguments in at the end.
 
 You can also put the docker-launch.sh script into your bin directory for the aws-azure-login command to function as usual:
 
-    sudo curl -o /usr/local/bin/aws-azure-login https://raw.githubusercontent.com/sportradar/aws-azure-login/main/docker-launch.sh -L
+    sudo curl -o /usr/local/bin/aws-azure-login https://raw.githubusercontent.com/aws-azure-login/aws-azure-login/main/docker-launch.sh -L
     sudo chmod o+x /usr/local/bin/aws-azure-login
 
 Now just run `aws-azure-login`.

--- a/docker-launch.sh
+++ b/docker-launch.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker run --rm -it -v ~/.aws:/root/.aws sportradar/aws-azure-login "$@"
+docker run --rm -it -v ~/.aws:/root/.aws aws-azure-login/aws-azure-login "$@"


### PR DESCRIPTION
These updates are to get a new official image with the fix for #266.

- Updated the runtime dependencies for Puppeteer according to [here](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#chrome-headless-disables-gpu-compositing)
- Updated the GitHub Actions release workflow to publish to `aws-azure-login` namespace instead of `sportradar`
- Updated README.md and docker-launch.sh to use `aws-azure-login` namespace instead of `sportradar`