### PR TITLE
Updated workflows to use node 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
       - run: yarn install
       - run: yarn test
       - run: yarn build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
       - run: yarn install
       - run: yarn test
       - run: yarn build
@@ -32,7 +32,7 @@ jobs:
           path: lib
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
           registry-url: https://registry.npmjs.org/
       - run: npm publish
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,21 +2,21 @@
 
 ## Get started
 
-This project is written in TypeScript and is using prettier and eslint for code formatting. You need node v14.
+This project is written in TypeScript and is using prettier and eslint for code formatting. You need node v18.
 
-1. Install node v14. I recommend installing that with nvm: https://github.com/nvm-sh/nvm
-
-```sh
-nvm install 14
-```
-
-2. Make node v14 default
+1. Install node v18. I recommend installing that with nvm: https://github.com/nvm-sh/nvm
 
 ```sh
-nvm alias default 14
+nvm install 18
 ```
 
-3. Open a new terminal and verify node version (should return v14.X.X)
+2. Make node v18 default
+
+```sh
+nvm alias default 18
+```
+
+3. Open a new terminal and verify node version (should return v18.X.X)
 
 ```sh
 node -v


### PR DESCRIPTION
Using node 18 fixes publishing errors during the publish-npm stage of the release workflow.  Build has been tested against node 18 successfully.