### PR TITLE
Update workflow and add multi-arch support 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -19,7 +19,7 @@ jobs:
       - run: yarn build
       - uses: actions/upload-artifact@v2
         with:
-          name: lib
+          name: lib-${{ github.run_id }}
           path: lib
 
   publish-npm:
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: lib
+          name: lib-${{ github.run_id }}
           path: lib
       - uses: actions/setup-node@v4
         with:
@@ -43,10 +43,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
-          name: lib
+          name: lib-${{ github.run_id }}
           path: lib
       - name: Publish to Registry
         uses: elgohr/Publish-Docker-Github-Action@master
@@ -61,10 +61,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
-          name: lib
+          name: lib-${{ github.run_id }}
           path: lib
       - uses: snapcore/action-build@v1
         id: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,13 +49,14 @@ jobs:
           name: lib-${{ github.run_id }}
           path: lib
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: aws-azure-login/aws-azure-login
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           snapshot: true
           dockerfile: Dockerfile
+          platforms: linux/amd64,linux/arm64
 
   publish-snap:
     needs: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-slim
+FROM node:18-slim
 
 # Install Puppeteer dependencies: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch
 RUN apt-get update \
@@ -39,13 +39,16 @@ RUN apt-get update \
    lsb-release \
    wget \
    xdg-utils \
+   chromium \
    && apt-get -q -y clean \
    && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 
+RUN ln -s /usr/bin/chromium /usr/bin/chromium-browser
+
 COPY package.json yarn.lock /aws-azure-login/
 
-RUN cd /aws-azure-login \
-   && yarn install --production
+WORKDIR /aws-azure-login
+RUN yarn install --production
 
 COPY lib /aws-azure-login/lib
 


### PR DESCRIPTION
- Update download and upload artifact actions to v4, as GitHub had deprecated older versions of these two actions. See the [announcement](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/).
- Add support for multi-arch docker image