### PR TITLE
Fix for #335 and #339 (broken login after cheerio update)

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -3,7 +3,7 @@ import Bluebird from "bluebird";
 import inquirer, { QuestionCollection, Question } from "inquirer";
 import zlib from "zlib";
 import { STS, STSClientConfig } from "@aws-sdk/client-sts";
-import * as cheerio from "cheerio";
+import { load } from "cheerio";
 import { v4 } from "uuid";
 import puppeteer, { HTTPRequest } from "puppeteer";
 import querystring from "querystring";
@@ -889,7 +889,7 @@ export const login = {
     debug("Converted", samlText);
 
     debug("Parsing SAML XML");
-    const saml = cheerio.load(samlText, { xmlMode: true });
+    const saml = load(samlText, { xmlMode: true });
 
     debug("Looking for role SAML attribute");
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/src/login.ts
+++ b/src/login.ts
@@ -3,7 +3,7 @@ import Bluebird from "bluebird";
 import inquirer, { QuestionCollection, Question } from "inquirer";
 import zlib from "zlib";
 import { STS, STSClientConfig } from "@aws-sdk/client-sts";
-import cheerio from "cheerio";
+import * as cheerio from "cheerio";
 import { v4 } from "uuid";
 import puppeteer, { HTTPRequest } from "puppeteer";
 import querystring from "querystring";


### PR DESCRIPTION
Possible fix for upstream issue #335 and #339.

The exception was happening on `cheerio.load()`

> TypeError: Cannot read properties of undefined (reading 'load')

According to https://cheerio.js.org/docs/api/interfaces/CheerioAPI#load is marked as deprecated with the message:

> The .load static method defined on the "loaded" Cheerio factory function is deprecated. Users are encouraged to instead use the load function exported by the Cheerio module.

This is a crude fix as I don't sufficiently understand TypeScript and a more specific fix to ensure that the code is using "the load function exported by the Cheerio module" may be more appropriate? 