### PR TITLE
Update Package.json cheerio version to fix XML Parse error

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@aws-sdk/client-sts": "^3.473.0",
     "@smithy/node-http-handler": "^2.5.0",
     "bluebird": "^3.7.2",
-    "cheerio": "1.0.0-rc.12",
+    "cheerio": "^1.0.0-rc.10 <1.0.0",
     "commander": "^9.5.0",
     "debug": "^4.3.1",
     "ini": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@aws-sdk/client-sts": "^3.473.0",
     "@smithy/node-http-handler": "^2.5.0",
     "bluebird": "^3.7.2",
-    "cheerio": "1.0.0-rc.10",
+    "cheerio": "1.0.0-rc.12",
     "commander": "^9.5.0",
     "debug": "^4.3.1",
     "ini": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@aws-sdk/client-sts": "^3.473.0",
     "@smithy/node-http-handler": "^2.5.0",
     "bluebird": "^3.7.2",
-    "cheerio": "^1.0.0-rc.10",
+    "cheerio": "1.0.0-rc.10",
     "commander": "^9.5.0",
     "debug": "^4.3.1",
     "ini": "^3.0.1",


### PR DESCRIPTION
With a fresh install of this module, it is defaulting to 1.0.0 for cheerio

error: 
TypeError: Cannot read properties of undefined (reading 'load')
    at Object._parseRolesFromSamlResponse (/opt/homebrew/lib/node_modules/aws-azure-login/lib/login.js:663:40)
    at Object.loginAsync (/opt/homebrew/lib/node_modules/aws-azure-login/lib/login.js:379:28)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

I pinned the cheerio version package.json to "1.0.0-rc.12" for this, and it works without any modifications to the code.

This is the most simplest fix I could think of. I hope this gets approved as this will be my first ever pull request that gets accepted, if it does! I hope I can contribute more in the future!